### PR TITLE
update legend for line graphs to match design

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "A package to build charts to CFPB style",
   "main": "index.js",
   "scripts": {

--- a/src/charts/LineChart.js
+++ b/src/charts/LineChart.js
@@ -166,7 +166,10 @@ function LineChart( properties ) {
 
     // add the legend
     var legendPositions = [
-      [ 0, -55 ], [ 0, -35 ], [ width / 4, -55 ], [ width / 4, -35 ]     
+      [ -70, -65 ],
+      [ -70, -45 ], 
+      [ width / 4, -55 ], 
+      [ width / 4, -35 ]     
     ];
     for ( var key in lineSets ) {
       if ( lineSets[key].showInLegend !== false ) {


### PR DESCRIPTION
Updates where the legend appears to it more closely matches the position in the designs.

![screen shot 2016-12-12 at 10 10 26 pm](https://cloud.githubusercontent.com/assets/702526/21126057/0f6cd688-c0b8-11e6-9dfd-e5d0fa48cc7d.png)
