### PR TITLE
add a group element for legend

### DIFF
--- a/src/charts/TileMap.js
+++ b/src/charts/TileMap.js
@@ -38,10 +38,17 @@ function TileMap( properties ) {
         .attr( 'width', width + margin.left + margin.right)
         .attr( 'height', height + margin.top + margin.bottom)
       .append( 'g' )
+        .classed( 'tiles' , true )
         .attr( 'transform', 
               'translate( ' + margin.left + ',' + margin.top + ' )' );
 
-    var tiles = svg.selectAll( 'g' )
+    // Add legend group
+    svg.append( 'g' )
+        .classed( 'legend' , true );
+
+    var legend = svg.selectAll('.legend');
+
+    var tiles = svg.selectAll( '.tiles' )
       .data( data )
       .enter();
 
@@ -102,7 +109,7 @@ function TileMap( properties ) {
 
     // draw the legend, rectangles
     for ( var x = 0; x < valueGrid.length; x++ ) {
-      svg.append( 'rect' )
+      legend.append( 'rect' )
         .attr( 'x', x * tileWidth + 15 )
         .attr( 'y', 0 )
         .attr( 'width', tileWidth )
@@ -113,7 +120,7 @@ function TileMap( properties ) {
 
     // draw the legend, text labels
     for ( var x = 0; x < legendLabels.length; x++ ) {
-      svg.append( 'text' )
+      legend.append( 'text' )
         .attr( 'x', x * tileWidth + 15 )
         .attr( 'y', 20 + tileWidth * .125 )
         .attr( 'width', tileWidth )


### PR DESCRIPTION
adds new `g` element to the tile map svg for easier positioning of legend elements (the group as a whole and the text, see corresponding PR with charts.less updates here: https://github.com/cfpb/consumer-credit-trends/pull/29)

## Additions

- variable and group for the legend elements

## Changes

- add a class name to the rest of the tilemap so the data isn't entered for all `g` elements (now that there's more than 1)

## Testing

- check this out and run npm link here and `npm link cfpb-chart-builder` in the other repo. then build JS + CSS with gulp watch to reload the code

## Review

- @mistergone 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2016-12-13 at 5 13 23 pm](https://cloud.githubusercontent.com/assets/702526/21161747/e320ab90-c157-11e6-8fd2-095af2c4fc05.png)


![screen shot 2016-12-13 at 5 17 21 pm](https://cloud.githubusercontent.com/assets/702526/21161777/09cc5186-c158-11e6-8a12-158b9e877352.png)


