### PR TITLE
update all map attributes to tile_map to match Wagtail

### DIFF
--- a/src/charts/TileMap.js
+++ b/src/charts/TileMap.js
@@ -32,7 +32,7 @@ function TileMap( props ) {
       }
     },
     series: [ {
-      type: 'tile_map',
+      type: 'map',
       borderColor: 'rgb(117, 120, 123)',
       states: {
         hover: {

--- a/src/charts/TileMap.js
+++ b/src/charts/TileMap.js
@@ -32,7 +32,7 @@ function TileMap( props ) {
       }
     },
     series: [ {
-      type: 'map',
+      type: 'tile_map',
       borderColor: 'rgb(117, 120, 123)',
       states: {
         hover: {

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ documentReady( function() {
         createChart.bar( properties );
       }
 
-      if ( type === 'tile_map' ) {
+      if ( type === 'map' ) {
         properties.data = process.map( data, group );
         createChart.map( properties );
       }

--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,7 @@ documentReady( function() {
         createChart.bar( properties );
       }
 
-      if ( type === 'map' ) {
+      if ( type === 'tile_map' ) {
         properties.data = process.map( data, group );
         createChart.map( properties );
       }

--- a/test/index.html
+++ b/test/index.html
@@ -37,7 +37,7 @@
     </div>
 
     <div class="cfpb-chart"
-         data-chart-type="map"
+         data-chart-type="tile_map"
          data-chart-title="Map about something"
          data-chart-color="navy"
          data-chart-description="This is the chart description."
@@ -76,7 +76,7 @@
     </div>
 
     <div class="cfpb-chart"
-         data-chart-type="map"
+         data-chart-type="tile_map"
          data-chart-title="This is the tile map title"
          data-chart-color="navy"
          data-chart-description="This is the chart description."

--- a/test/sample-data.js
+++ b/test/sample-data.js
@@ -18,7 +18,7 @@ var charts = [{
   "elementID": "figure-1a__volume__auto-loans"
  }, {
   "title": "",
-  "chartType": "map",
+  "chartType": "tile_map",
   "market": "auto-loans",
   "reportType": "origination-activity",
   "figureID": "figure-1c",
@@ -309,7 +309,7 @@ var charts = [{
   "elementID": "figure-1a__volume__credit-cards"
  }, {
   "title": "",
-  "chartType": "map",
+  "chartType": "tile_map",
   "market": "credit-cards",
   "reportType": "origination-activity",
   "figureID": "figure-1c",
@@ -600,7 +600,7 @@ var charts = [{
   "elementID": "figure-1a__volume__mortgages"
  }, {
   "title": "",
-  "chartType": "map",
+  "chartType": "tile_map",
   "market": "mortgages",
   "reportType": "origination-activity",
   "figureID": "figure-1c",
@@ -891,7 +891,7 @@ var charts = [{
   "elementID": "figure-1a__volume__student-loans"
  }, {
   "title": "",
-  "chartType": "map",
+  "chartType": "tile_map",
   "market": "student-loans",
   "reportType": "origination-activity",
   "figureID": "figure-1c",


### PR DESCRIPTION
There's a bug in our tile maps in Wagtail where the expected attribute string is `tile_map`, but the output from chart-builder is actually the string `map`: https://github.com/cfpb/cfgov-refresh/pull/2688/files#diff-dcf2a8703e945442ba8591d07085a645R672

Maps won't render in Wagtail at all because of this.

We could either change it to `map` in Wagtail which requires a migration or we can update chart builder here. I've chosen to update the attribute name in chart builder because it's more specific and consistent with the type of chart. Since we may add geographic maps or other types of maps in the future, calling this 'tile_map' makes this more future friendly.


## Testing

- test the local index page http://localhost:8088/test/
- npm link this branch and test it locally in Wagtail.

## Review

- @contolini 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

Here is what the test map should look like in Wagtail.
![screen shot 2017-01-27 at 3 58 43 pm](https://cloud.githubusercontent.com/assets/702526/22387406/83aad15c-e4a9-11e6-8ae1-9a8440bdcefd.png)


