### PR TITLE
Change axis line, tick mark, and interval line colors to match approved designs

### DIFF
--- a/src/charts/BarChart.js
+++ b/src/charts/BarChart.js
@@ -85,6 +85,8 @@ function BarChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         },
       },
+      lineColor: '#75787b',
+      tickColor: '#75787b',
       startOnTick: true,
       type: 'datetime',
       dateTimeLabelFormats: {
@@ -115,6 +117,8 @@ function BarChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         }
       },
+      lineColor: '#75787b',
+      tickColor: '#75787b',
       title: {
         text: 'Year-over-year change (%)',
         style: {

--- a/src/charts/BarChart.js
+++ b/src/charts/BarChart.js
@@ -85,8 +85,9 @@ function BarChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         },
       },
-      lineColor: '#75787b',
-      tickColor: '#75787b',
+      lineColor: '#d2d3d5',
+      tickColor: '#d2d3d5',
+      gridLineColor: '#d2d3d5',
       startOnTick: true,
       type: 'datetime',
       dateTimeLabelFormats: {
@@ -117,8 +118,9 @@ function BarChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         }
       },
-      lineColor: '#75787b',
-      tickColor: '#75787b',
+      lineColor: '#d2d3d5',
+      tickColor: '#d2d3d5',
+      gridLineColor: '#d2d3d5',
       title: {
         text: 'Year-over-year change (%)',
         style: {

--- a/src/charts/LineChart.js
+++ b/src/charts/LineChart.js
@@ -190,6 +190,8 @@ function LineChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         },
       },
+      lineColor: '#75787b',
+      tickColor: '#75787b',
       plotLines: [ {
         color: '#75787b',
         width: 1,
@@ -224,7 +226,9 @@ function LineChart( props ) {
           fontSize: '16px',
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         }
-      }
+      },
+      lineColor: '#75787b',
+      tickColor: '#75787b'
     },
     series: [
       {

--- a/src/charts/LineChart.js
+++ b/src/charts/LineChart.js
@@ -190,8 +190,9 @@ function LineChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         },
       },
-      lineColor: '#75787b',
-      tickColor: '#75787b',
+      lineColor: '#d2d3d5',
+      tickColor: '#d2d3d5',
+      gridLineColor: '#d2d3d5'
       plotLines: [ {
         color: '#75787b',
         width: 1,
@@ -227,8 +228,9 @@ function LineChart( props ) {
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
         }
       },
-      lineColor: '#75787b',
-      tickColor: '#75787b'
+      lineColor: '#d2d3d5',
+      tickColor: '#d2d3d5',
+      gridLineColor: '#d2d3d5'
     },
     series: [
       {


### PR DESCRIPTION
Our code accidentally went live with the default Highcharts styling, rather than our recommended styling for CFPB. This corrects the colors used for all axis lines, tick marks, and interval lines.

## Additions

- Set color values for X and Y axis lines, tick marks, and interval lines to CFPB Gray 20

## Testing

- Load up the branch, and look at the test charts. The colors for the X axis, Y axis, tick marks, and interval lines should be #d2d3d5 (aka CFPB Gray 20). Most importantly, no axes should be light blue.

## Review

- @mistergone 
- @cfarm 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

Currently in production:

![screen shot 2017-02-10 at 11 33 46 am](https://cloud.githubusercontent.com/assets/1183435/22834984/19dd3224-ef85-11e6-8023-afb2734765dd.png)

This pull request:

![screen shot 2017-02-10 at 11 34 01 am](https://cloud.githubusercontent.com/assets/1183435/22834988/200bb3dc-ef85-11e6-9688-3a592d27315f.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
