### PR TITLE
fix all chart labels to match design color gray-80

### DIFF
--- a/src/static/js/charts/BarChart.js
+++ b/src/static/js/charts/BarChart.js
@@ -82,7 +82,8 @@ function BarChart( props ) {
       labels: {
         style: {
           fontSize: '16px',
-          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
+          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
+          color: '#75787b'
         }
       },
       lineColor: '#d2d3d5',
@@ -115,7 +116,8 @@ function BarChart( props ) {
       labels: {
         style: {
           fontSize: '16px',
-          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
+          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
+          color: '#75787b'
         }
       },
       lineColor: '#d2d3d5',

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -187,8 +187,9 @@ function LineChart( props ) {
       labels: {
         style: {
           fontSize: '16px',
-          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
-        },
+          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
+          color: '#75787b'
+        }
       },
       lineColor: '#d2d3d5',
       tickColor: '#d2d3d5',
@@ -225,7 +226,8 @@ function LineChart( props ) {
         },
         style: {
           fontSize: '16px',
-          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
+          fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
+          color: '#75787b'
         }
       },
       lineColor: '#d2d3d5',


### PR DESCRIPTION
Fixes GHE #614

## Additions

- Adds hex code for some axis labels (month/year and y axis labels) so that they are gray-80 to match designs


## Review

- @marteki 
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2017-02-24 at 1 46 45 pm](https://cloud.githubusercontent.com/assets/702526/23316279/c98d34fe-fa97-11e6-9da8-13e8f69ef917.png)

