### PR TITLE
Fix/axis colors a11y

### DIFF
--- a/src/static/js/charts/BarChart.js
+++ b/src/static/js/charts/BarChart.js
@@ -83,7 +83,7 @@ function BarChart( props ) {
         style: {
           fontSize: '16px',
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
-          color: '#75787b'
+          color: '#5a5d61'
         }
       },
       lineColor: '#d2d3d5',
@@ -105,7 +105,7 @@ function BarChart( props ) {
           align: 'right',
           rotation: 0,
           style: {
-            color: '#75787b'
+            color: '#5a5d61'
           },
           y: -15
         }
@@ -117,7 +117,7 @@ function BarChart( props ) {
         style: {
           fontSize: '16px',
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
-          color: '#75787b'
+          color: '#5a5d61'
         }
       },
       lineColor: '#d2d3d5',
@@ -126,7 +126,7 @@ function BarChart( props ) {
       title: {
         text: 'Year-over-year change (%)',
         style: {
-          'color': '#75787b',
+          'color': '#5a5d61',
           'font-size': '16px'
         }
       }
@@ -163,7 +163,7 @@ function BarChart( props ) {
     function( chart ) {
       chart.renderer.text( 'Select time range', 7, 16 )
         .css( {
-          color: '#75787b',
+          color: '#5a5d61',
           fontSize: '14px'
         } )
         .add();

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -12,7 +12,8 @@ Highcharts.setOptions( {
   chart: {
     style: {
       fontSize: '16px',
-      fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
+      fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
+      'color': '#5a5d61'
     }
   }
 } );
@@ -144,7 +145,7 @@ function LineChart( props ) {
       floating: true,
       itemMarginTop: 10,
       itemStyle: {
-        'color': '#75787b',
+        'color': '#5a5d61',
         'font-weight': 'normal',
         'font-size': '16px'
       },
@@ -188,7 +189,7 @@ function LineChart( props ) {
         style: {
           fontSize: '16px',
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
-          color: '#75787b'
+          color: '#5a5d61'
         }
       },
       lineColor: '#d2d3d5',
@@ -204,7 +205,7 @@ function LineChart( props ) {
           align: 'right',
           rotation: 0,
           style: {
-            color: '#75787b'
+            color: '#5a5d61'
           },
           y: -15
         }
@@ -217,7 +218,7 @@ function LineChart( props ) {
       title: {
         text: _getYAxisLabel( props.data.adjusted ) + ' of originations (in ' + _getYAxisUnits( props.data.adjusted ) + ')',
         style: {
-          color: '#75787b'
+          color: '#5a5d61'
         }
       },
       labels: {
@@ -227,7 +228,7 @@ function LineChart( props ) {
         style: {
           fontSize: '16px',
           fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif",
-          color: '#75787b'
+          color: '#5a5d61'
         }
       },
       lineColor: '#d2d3d5',
@@ -274,7 +275,7 @@ function LineChart( props ) {
     function( chart ) {
       chart.renderer.text( 'Select time range', 7, 16 )
         .css( {
-          color: '#75787b',
+          color: '#5a5d61',
           fontSize: '14px'
         } )
         .add();

--- a/src/static/js/charts/TileMap.js
+++ b/src/static/js/charts/TileMap.js
@@ -13,7 +13,7 @@ function _drawLegend( chart ) {
   };
 
   var textStyle = {
-    color: '#75787b',
+    color: '#5a5d61',
     fontSize: '16px',
     fontFamily: "'AvenirNextLTW01-Regular',Arial,sans-serif"
   };


### PR DESCRIPTION
Fixes GHE #614 AND updates for a11y to gray

## Additions

- Adds hex code for axis labels (month/year and y axis labels) so that they are gray
- Includes bar, map and line


## Review

- @mistergone  
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

![screen shot 2017-02-24 at 6 17 26 pm](https://cloud.githubusercontent.com/assets/702526/23324721/9eeef93c-fabd-11e6-9d29-a3d344599eb3.png)
![screen shot 2017-02-24 at 6 17 20 pm](https://cloud.githubusercontent.com/assets/702526/23324723/9eefef0e-fabd-11e6-9811-cad7d2179dac.png)
![screen shot 2017-02-24 at 6 17 15 pm](https://cloud.githubusercontent.com/assets/702526/23324722/9eef6e80-fabd-11e6-9388-7adb581870fe.png)
