### PR TITLE
Revert button width for now

### DIFF
--- a/src/static/js/charts/BarChart.js
+++ b/src/static/js/charts/BarChart.js
@@ -24,13 +24,15 @@ function BarChart( props ) {
       selected: 'all',
       height: 35,
       inputEnabled: false,
-      buttonSpacing: 15,
+/* TODO: buttonSpacing will be re-integrated with responsive styles */
+//      buttonSpacing: 15,
       buttonPosition: {
         x: 0,
         y: 30
       },
       buttonTheme: {
-        width: 45,
+/* TODO: width will be re-integrated with responsive styles */
+//        width: 45,
         r: 5, // border radius
         fill: '#CCE3F5',
         style: {

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -101,13 +101,15 @@ function LineChart( props ) {
       selected: 'all',
       height: 35,
       inputEnabled: false,
-      buttonSpacing: 15,
+/* TODO: buttonSpacing will be re-integrated with responsive styles */
+//      buttonSpacing: 15,
       buttonPosition: {
         x: 0,
         y: 30
       },
       buttonTheme: {
-        width: 45,
+/* TODO: width will be re-integrated with responsive styles */
+//        width: 45,
         r: 5, // border radius
         fill: '#CCE3F5',
         style: {


### PR DESCRIPTION
@ajbush noted that the increased button width causes some problems in mobile/small screen view, and asked me to revert the changes to the button width until we work on responsive views.

## Removals
- Comments out the change that made buttons wider

## Review
- @cfarm @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
