### PR TITLE
upgrade highcharts to 5.0.9 with ie8 fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "homepage": "https://github.com/cfpb/cfpb-chart-builder#readme",
   "dependencies": {
-    "highcharts": "https://github.com/mistergone/highcharts#ie8-fix",
+    "highcharts": "5.0.9",
     "xdr": "0.5.3",
     "cf-grid": "^4.0.1",
     "cf-layout": "^4.0.1",


### PR DESCRIPTION
Fixes #42 
