### PR TITLE
Fix tooltip colors

### DIFF
--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -436,17 +436,18 @@
       stroke-linecap: butt;
     }
 
-    // Unadjusted
+
+    // Seasonally adjusted 
     .highcharts-series-0 {
       .highcharts-graph {
-        stroke-width: 1px;
+        stroke-width: 4px;
       }
     }
 
-    // Seasonally adjusted 
+    // Unadjusted
     .highcharts-series-1 {
       .highcharts-graph {
-        stroke-width: 4px;
+        stroke-width: 1px;
       }
     }
 

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -172,7 +172,7 @@
       
     }
 
-    &.highcharts-color-0 {
+    &.highcharts-color-1 {
       position: relative !important;
       top: 46px !important;
 
@@ -455,14 +455,14 @@
       stroke-dasharray: 5, 5;
     }
 
-    .highcharts-color-0 .highcharts-zone-graph-1 {
+    .highcharts-color-1 .highcharts-zone-graph-1 {
       stroke-dasharray: 3, 3;
     }
 
     &[data-chart-color='blue'] {
 
-      .highcharts-color-0, 
-      .highcharts-color-1,
+      .highcharts-color-1, 
+      .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph  {
         stroke: @chart-blue-primary;
       }
@@ -471,8 +471,8 @@
 
     &[data-chart-color='green'] {
 
-      .highcharts-color-0, 
-      .highcharts-color-1,
+      .highcharts-color-1, 
+      .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph {
         stroke: @chart-green-primary;
       }
@@ -482,8 +482,8 @@
     &[data-chart-color='teal'] {
 
 
-      .highcharts-color-0, 
-      .highcharts-color-1,
+      .highcharts-color-1, 
+      .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph  {
         stroke: @chart-teal-primary;
       }
@@ -492,8 +492,8 @@
 
     &[data-chart-color='navy'] {
 
-      .highcharts-color-0, 
-      .highcharts-color-1,
+      .highcharts-color-1, 
+      .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph  {
         stroke: @chart-navy-primary;
       }
@@ -570,7 +570,7 @@
 
   }
 
-  // Navigator graph (mini-graph under main graph on large screens)
+  // Navigator graph (mini-graph under main graph on large screens) and tooltip styles
   .highcharts-navigator-series .highcharts-graph {
     stroke-width: 2px;
   }
@@ -583,6 +583,15 @@
 
     .highcharts-navigator-series .highcharts-graph.highcharts-zone-graph-1  {
       stroke: @chart-blue-secondary;
+    }
+
+    .highcharts-tooltip {
+      .highcharts-color-1, .highcharts-color-0 {
+        fill: @chart-blue-primary;
+      }
+      .highcharts-color-0 {
+
+      }
     }
 
   }

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -436,7 +436,6 @@
       stroke-linecap: butt;
     }
 
-
     // Seasonally adjusted 
     .highcharts-series-0 {
       .highcharts-graph {
@@ -588,10 +587,15 @@
 
     .highcharts-tooltip {
       .highcharts-color-1, .highcharts-color-0 {
-        fill: @chart-blue-primary;
+        display: inline-block;
+        height: 4px;
+        width: 15px;
+        margin-bottom: 3px;
+        background: @chart-blue-primary;
       }
-      .highcharts-color-0 {
-
+      .highcharts-color-1 {
+        height: 1px;
+        margin-bottom: 5px;
       }
     }
 
@@ -607,6 +611,20 @@
       stroke: @chart-green-secondary;
     }
 
+    .highcharts-tooltip {
+      .highcharts-color-1, .highcharts-color-0 {
+        display: inline-block;
+        height: 4px;
+        width: 15px;
+        margin-bottom: 3px;
+        background: @chart-green-primary;
+      }
+      .highcharts-color-1 {
+        height: 1px;
+        margin-bottom: 5px;
+      }
+    }
+
   }
 
   &[data-chart-color='teal'] {
@@ -620,6 +638,20 @@
       stroke: @chart-teal-secondary;
     }
 
+    .highcharts-tooltip {
+      .highcharts-color-1, .highcharts-color-0 {
+        display: inline-block;
+        height: 4px;
+        width: 15px;
+        margin-bottom: 3px;
+        background: @chart-teal-primary;
+      }
+      .highcharts-color-1 {
+        height: 1px;
+        margin-bottom: 5px;
+      }
+    }
+
   }
 
   &[data-chart-color='navy'] {
@@ -630,6 +662,20 @@
 
     .highcharts-navigator-series .highcharts-graph.highcharts-zone-graph-1  {
       stroke: @chart-navy-secondary;
+    }
+
+    .highcharts-tooltip {
+      .highcharts-color-1, .highcharts-color-0 {
+        display: inline-block;
+        height: 4px;
+        width: 15px;
+        margin-bottom: 3px;
+        background: @chart-navy-primary;
+      }
+      .highcharts-color-1 {
+        height: 1px;
+        margin-bottom: 5px;
+      }
     }
 
   }

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -55,7 +55,8 @@
   .highcharts-root,
   .highcharts-container,
   .highcharts-legend-box,
-  .highcharts-axis-labels {
+  .highcharts-axis-labels,
+  .highcharts-tooltip text {
     .chart-label();
   }
 
@@ -467,6 +468,20 @@
         stroke: @chart-blue-primary;
       }
 
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-blue-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
+      }
+
     }
 
     &[data-chart-color='green'] {
@@ -475,6 +490,20 @@
       .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph {
         stroke: @chart-green-primary;
+      }
+
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-green-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
       }
 
     }
@@ -488,6 +517,20 @@
         stroke: @chart-teal-primary;
       }
 
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-teal-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
+      }
+
     }
 
     &[data-chart-color='navy'] {
@@ -496,6 +539,20 @@
       .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph  {
         stroke: @chart-navy-primary;
+      }
+
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-navy-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
       }
 
     }
@@ -515,6 +572,10 @@
 
     }
 
+    .highcharts-tooltip .highcharts-color-0 {
+      display: none;
+    }
+
     &[data-chart-color='blue'] {
 
         .highcharts-point {
@@ -524,6 +585,10 @@
             fill: @chart-blue-primary;
           }
 
+        }
+
+        .highcharts-tooltip-box {
+          stroke: @chart-blue-primary;
         }
         
     }
@@ -538,6 +603,10 @@
           }
 
         }
+
+        .highcharts-tooltip-box {
+          stroke: @chart-green-primary;
+        }
         
     }
 
@@ -550,6 +619,10 @@
             fill: @chart-teal-primary;
           }
 
+        }
+
+        .highcharts-tooltip-box {
+          stroke: @chart-teal-primary;
         }
         
     }
@@ -564,13 +637,17 @@
           }
 
         }
+
+        .highcharts-tooltip-box {
+          stroke: @chart-navy-primary;
+        }
         
     }
 
 
   }
 
-  // Navigator graph (mini-graph under main graph on large screens) and tooltip styles
+  // Navigator graph (mini-graph under main graph on large screens)
   .highcharts-navigator-series .highcharts-graph {
     stroke-width: 2px;
   }
@@ -585,20 +662,6 @@
       stroke: @chart-blue-secondary;
     }
 
-    .highcharts-tooltip {
-      .highcharts-color-1, .highcharts-color-0 {
-        display: inline-block;
-        height: 4px;
-        width: 15px;
-        margin-bottom: 3px;
-        background: @chart-blue-primary;
-      }
-      .highcharts-color-1 {
-        height: 1px;
-        margin-bottom: 5px;
-      }
-    }
-
   }
 
   &[data-chart-color='green'] {
@@ -609,20 +672,6 @@
 
     .highcharts-navigator-series .highcharts-graph.highcharts-zone-graph-1  {
       stroke: @chart-green-secondary;
-    }
-
-    .highcharts-tooltip {
-      .highcharts-color-1, .highcharts-color-0 {
-        display: inline-block;
-        height: 4px;
-        width: 15px;
-        margin-bottom: 3px;
-        background: @chart-green-primary;
-      }
-      .highcharts-color-1 {
-        height: 1px;
-        margin-bottom: 5px;
-      }
     }
 
   }
@@ -638,20 +687,6 @@
       stroke: @chart-teal-secondary;
     }
 
-    .highcharts-tooltip {
-      .highcharts-color-1, .highcharts-color-0 {
-        display: inline-block;
-        height: 4px;
-        width: 15px;
-        margin-bottom: 3px;
-        background: @chart-teal-primary;
-      }
-      .highcharts-color-1 {
-        height: 1px;
-        margin-bottom: 5px;
-      }
-    }
-
   }
 
   &[data-chart-color='navy'] {
@@ -662,20 +697,6 @@
 
     .highcharts-navigator-series .highcharts-graph.highcharts-zone-graph-1  {
       stroke: @chart-navy-secondary;
-    }
-
-    .highcharts-tooltip {
-      .highcharts-color-1, .highcharts-color-0 {
-        display: inline-block;
-        height: 4px;
-        width: 15px;
-        margin-bottom: 3px;
-        background: @chart-navy-primary;
-      }
-      .highcharts-color-1 {
-        height: 1px;
-        margin-bottom: 5px;
-      }
     }
 
   }

--- a/src/static/js/charts/BarChart.js
+++ b/src/static/js/charts/BarChart.js
@@ -100,6 +100,9 @@ function BarChart( props ) {
         reserveSpace: false
       }
     },
+    tooltip: {
+      useHTML: true
+    },
     series: [ {
       type: 'column',
       data: props.data,

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -179,6 +179,17 @@ function LineChart( props ) {
         }
       }
     },
+    tooltip: {
+      useHTML: true,
+      formatter: function() {
+        var tooltip = Highcharts.dateFormat('%B %Y', this.x);
+        for (var i = 0; i < this.points.length; i++) {
+          var point = this.points[i];
+          tooltip += "<br><span class='highcharts-color-" + point.series.colorIndex + "'></span> " + point.series.name+": " + Highcharts.numberFormat(point.y, 0);
+        }
+        return tooltip;
+      }
+    },
     series: [
       {
         name: 'Seasonally adjusted',

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -181,9 +181,9 @@ function LineChart( props ) {
     },
     series: [
       {
-        name: 'Unadjusted',
-        data: props.data.unadjusted,
-        legendIndex: 2,
+        name: 'Seasonally adjusted',
+        data: props.data.adjusted,
+        legendIndex: 1,
         tooltip: {
           valueDecimals: 0
         },
@@ -193,9 +193,9 @@ function LineChart( props ) {
         } ]
       },
       {
-        name: 'Seasonally adjusted',
-        data: props.data.adjusted,
-        legendIndex: 1,
+        name: 'Unadjusted',
+        data: props.data.unadjusted,
+        legendIndex: 2,
         tooltip: {
           valueDecimals: 0
         },


### PR DESCRIPTION
Updates the bar + line chart CSS + JS so that the colors and legend styles are matching to the charts.

## Additions

- custom format for the Line Chart tooltips - to show paths instead of bullets inside the tooltip (matching the legend)
- styles for the new Line Chart tooltips + Bar Chart tooltips

## Changes

- Updated the order of the series data in LineChart.js so that the seasonally adjusted data comes first in the legend AND tooltips. This necessitated CSS updates to match the proper index for the class names (swapped 0 and 1)

## Testing

- check out branch from upstream: `fix-tooltip-colors`
- run `./setup.sh`
- run `gulp watch` and review demo page in browser

## Review

- @mistergone 
- @nataliafitzgerald 
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots
![screen shot 2017-06-12 at 5 23 11 pm](https://user-images.githubusercontent.com/702526/27056264-68ba105e-4f95-11e7-84d1-e559401d9d59.png)
![screen shot 2017-06-12 at 5 23 04 pm](https://user-images.githubusercontent.com/702526/27056266-68c16228-4f95-11e7-9761-2e9bc1de2ec3.png)


## Notes

- I don't think we ever had a specific design for these, we just used the Highcharts defaults, but if there are specific changes to the font style and the colors of the tooltip elements we want to make to the design, feel free to mention or discuss them here.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
