### PR TITLE
Gracefully degrade line + bar charts for IE9: Hide time range buttons and fix legend positioning

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,7 +1,8 @@
 <!DOCTYPE html>
 <!--[if lt IE 7]>      <html lang="en" class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
 <!--[if IE 7]>         <html lang="en" class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html lang="en" class="no-js lt-ie9"> <![endif]-->
+<!--[if IE 8]>         <html lang="en" class="no-js lt-ie10 lt-ie9"> <![endif]-->
+<!--[if IE 9]>         <html lang="en" class="no-js lt-ie10"> <![endif]-->
 <!--[if gt IE 8]><!--> <html lang="en" class="no-js"> <!--<![endif]-->
 
 <head>
@@ -140,7 +141,7 @@
             <div class="cfpb-chart"
                  data-chart-type="line"
                  data-chart-title="Deep subprime (credit scores below 580)"
-                 data-chart-color="green"
+                 data-chart-color="navy"
                  data-chart-description="This is the chart description."
                  data-chart-metadata="Deep subprime"
                  data-chart-source="consumer-credit-trends/auto-loans/volume_data_Score_Level_AUT.csv">

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -14,6 +14,13 @@
 @chart-teal-primary: @teal;
 @chart-teal-secondary: @teal-60;
 
+.hide-on-ie9 {
+  .lt-ie10 & {
+    display: none;
+    visibility: hidden;
+  }
+}
+
 .cfpb-chart {
   position: relative;
   max-width: 650px;
@@ -173,9 +180,18 @@
     .respond-to-min( 800px, {
       transform: translate(465px, -6px) !important;
     });
+
+  }
+
+  .highcharts-legend-box {
+    transform: translate(-8px, -5px) !important;
   }
 
   .highcharts-legend-item {
+
+    .highcharts-graph {
+      .hide-on-ie9();
+    }
 
     span {
       margin-left: 25px !important;
@@ -186,6 +202,17 @@
       .respond-to-min( 450px, {
         white-space: nowrap !important;
       });
+
+      .lt-ie10 &:before {
+        content: '';
+        display: block;
+        position: absolute;
+        width: 15px;
+        height: 4px;
+        left: -25px;
+        top: 8px;
+        background: @chart-green-primary;
+      }
       
     }
 
@@ -261,6 +288,8 @@
       text-transform: none;
     });
 
+    .hide-on-ie9();
+
     span {
       display: table-cell;
       position: relative !important;
@@ -319,6 +348,8 @@
     .respond-to-min( 800px, {
       transform: translate(0px, 30px);
     } );
+
+    .hide-on-ie9();
 
     &:after {
       content: '';
@@ -474,6 +505,11 @@
       .highcharts-graph {
         stroke-width: 1px;
       }
+      span {
+        .lt-ie10 &:before {
+          height: 1px;
+        }
+      }
     }
 
     // Projected data for last six months
@@ -489,8 +525,12 @@
 
       .highcharts-color-1, 
       .highcharts-color-0,
-      .highcharts-navigator-series .highcharts-graph  {
+      .highcharts-navigator-series .highcharts-graph {
         stroke: @chart-blue-primary;
+      }
+
+      .highcharts-legend-item span:before  {
+        background: @chart-blue-primary;
       }
 
       .highcharts-tooltip {
@@ -542,6 +582,10 @@
         stroke: @chart-teal-primary;
       }
 
+      .highcharts-legend-item span:before  {
+        background: @chart-teal-primary;
+      }
+
       .highcharts-tooltip {
         .highcharts-color-1, .highcharts-color-0 {
           display: inline-block;
@@ -564,6 +608,10 @@
       .highcharts-color-0,
       .highcharts-navigator-series .highcharts-graph  {
         stroke: @chart-navy-primary;
+      }
+
+      .highcharts-legend-item span:before  {
+        background: @chart-navy-primary;
       }
 
       .highcharts-tooltip {

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -181,10 +181,12 @@
       transform: translate(465px, -6px) !important;
     });
 
-  }
+    .lt-ie10 & {
+      .respond-to-min( 800px, {
+        left: -465px !important;
+      });
+    }
 
-  .highcharts-legend-box {
-    transform: translate(-8px, -5px) !important;
   }
 
   .highcharts-legend-item {


### PR DESCRIPTION
Fixes CSS positioning bugs on SVG elements in IE9.

IE9 does not support CSS Transform styles when applied to SVG elements ([source](http://caniuse.com/#feat=transforms2d)). This technique is the only way I was able to achieve positioning the legend + time range button elements on the graphs with media queries to match our responsive designs.

This PR makes the following adjustments to IE9 styles to work around this lack of support:
- **Hides the time range buttons on IE9 line graphs**. IE9 users still have access to the default graph view and can download the CSV files to further explore the data in depth. Any data added to the graph in the future will automatically be visible in the default graph view, thanks to Highcharts.
- **Adds CSS pseudo elements workaround to mimic the Highcharts SVG elements in the legend**. This makes the legend look the same as it does in all browsers.


## Additions

- `lt-ie10` class to target ie9. this is the same as what is used in the [cfgov-refresh base template](https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/_layouts/base.html#L21).
- class to hide elements from IE9 that cannot be positioned by CSS, to avoid broken layout in that browser.
- CSS for styling pseudoelements to represent the lines for line chart legends in IE9. The SVGs produced by Highcharts cannot be positioned, so I used pseudoelements as a fallback.

## Testing

- [Watch video of IE9 on Sauce Labs](https://saucelabs.com/beta/tests/7264ed60abe644b6a8a94fc90513c24c/watch) scrolling thru charts starts at 1:40
- check out this branch 
- run `./setup.sh`
- `gulp watch` will open up the demo in your browser

## Review

- @mistergone 
- @anselmbradford 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

### Before
![image](https://user-images.githubusercontent.com/702526/27925846-35fa701a-6254-11e7-89c8-7e290c566ec9.png)

### After

#### small
![small screen line chart](https://user-images.githubusercontent.com/702526/27929907-c0fb3da8-6262-11e7-9712-ad3c54aa756d.png)
![small screen bar chart](https://user-images.githubusercontent.com/702526/27929903-c0f0f992-6262-11e7-9de3-bbe835746dc0.png)

#### medium
![medium screen line chart](https://user-images.githubusercontent.com/702526/27929908-c1028504-6262-11e7-9cfb-1848fb045068.png)
![medium screen bar chart](https://user-images.githubusercontent.com/702526/27929905-c0f63902-6262-11e7-94d8-48a0e379bacd.png)

#### large

![large screen line chart](https://user-images.githubusercontent.com/702526/27929904-c0f3d6d0-6262-11e7-9a18-73025fc59a57.png)
![large screen bar chart](https://user-images.githubusercontent.com/702526/27930011-1ef5b78a-6263-11e7-9635-c186bc99841a.png)



## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
