### PR TITLE
Add more whitespace to responsive chart labels on large screens

### DIFF
--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -462,7 +462,7 @@
       transform: rotate(0deg) translate(120px, -133px) !important;
 
       .respond-to-min( 655px, {
-        transform: rotate(-90deg) translate(-245px, -232px) !important;
+        transform: rotate(-90deg) translate(-255px, -232px) !important;
       } );
 
     }

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -459,7 +459,7 @@
 
     .highcharts-yaxis .highcharts-axis-title {
 
-      transform: rotate(0deg) translate(120px, -130px) !important;
+      transform: rotate(0deg) translate(120px, -133px) !important;
 
       .respond-to-min( 655px, {
         transform: rotate(-90deg) translate(-245px, -232px) !important;
@@ -482,7 +482,7 @@
       transform: rotate(0deg) translate(88px, -130px) !important;
       
       .respond-to-min( 800px, {
-        transform: rotate(-90deg) translate(-245px, -232px) !important;
+        transform: rotate(-90deg) translate(-270px, -232px) !important;
       } );
 
     }

--- a/src/static/js/charts/BarChart.js
+++ b/src/static/js/charts/BarChart.js
@@ -116,7 +116,24 @@ function BarChart( props ) {
         className: 'highcharts-data__unprojected'
       }, {
       } ]
-    } ]
+    } ],
+    responsive: {
+      rules: [{
+        condition: {
+          minWidth: 600 // chart width, not window width
+        },
+      // Add more left margin space for vertical label on large screens
+        chartOptions: {
+          chart: {
+            marginRight: 0,
+            marginTop: 100,
+            marginLeft: 70,
+            zoomType: 'none'
+          }
+        }
+      }]
+    }
+
   };
 
   Highcharts.stockChart( props.selector, options, function( chart ) {

--- a/src/static/js/charts/LineChart.js
+++ b/src/static/js/charts/LineChart.js
@@ -217,7 +217,23 @@ function LineChart( props ) {
           value: props.data.projectedDate.timestamp
         } ]
       }
-    ]
+    ],
+    responsive: {
+      rules: [{
+        condition: {
+          minWidth: 600 // chart width, not window width
+        },
+      // Add more left margin space for vertical label on large screens
+        chartOptions: {
+          chart: {
+            marginRight: 0,
+            marginTop: 100,
+            marginLeft: 70,
+            zoomType: 'none'
+          }
+        }
+      }]
+    }
   };
 
   Highcharts.stockChart( props.selector, options, function( chart ) {


### PR DESCRIPTION
This fixes a formatting issue where some chart labels overlap or almost overlap the axis labels on large screen sizes, where the design switches to a vertical-oriented label on the left margin.

## Additions

- responsive chart options for changing the left margin space on large screens (when the chart is 600px wide or larger)

## Changes

- tweaks the positioning of the large-screen vertical chart labels to more closely match the design

## Testing

- check out branch
- run `gulp build` and `gulp watch`
- confirm that charts look the same on small screens as on master (see screenshots in #51)
- confirm that for large screen sizes, the chart labels on the left no longer overlap

## Review

- @mistergone or @anselmbradford 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

### Before - showing overlap/not enough whitespace issue
![screen shot 2017-07-24 at 11 41 57 am](https://user-images.githubusercontent.com/702526/28531999-6e4d6484-7066-11e7-9c35-76ff95ffb502.png)

![screen shot 2017-07-24 at 11 42 01 am](https://user-images.githubusercontent.com/702526/28531998-6e4af87a-7066-11e7-997e-a4e01842dbb3.png)


### After - overlap fixed
![screen shot 2017-07-24 at 11 46 23 am](https://user-images.githubusercontent.com/702526/28531990-696defa6-7066-11e7-9473-6e4df0257342.png)

![screen shot 2017-07-24 at 11 46 28 am](https://user-images.githubusercontent.com/702526/28531989-696a8d70-7066-11e7-91a1-c103737da9dd.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
