### PR TITLE
Fix legend label position

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Charts for the Consumer Financial Protection Bureau",
   "main": "src/static/js/index.js",
   "scripts": {

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -184,6 +184,14 @@
       transform: translate(465px, -6px) !important;
     });
 
+    .respond-to-min( 900px, {
+      transform: translate(445px, -6px) !important;
+    });
+
+    .respond-to-min( 926px, {
+      transform: translate(465px, -6px) !important;
+    });
+
     .lt-ie10 & {
       .respond-to-min( 800px, {
         left: -465px !important;


### PR DESCRIPTION
Fixes issue discovered in cfgov-refresh where the legend label text ("Seasonally adjusted") on large screens gets cut off
 
## Additions

- Media query for breakpoints between 900 and 926 pixels wide



## Testing

- can only be tested on cfgov-refresh, as this is only an issue within the Wagtail template layout and can't be duplicated in this repo's demo page layout. npm link is broken for that project right now, so I tested this code with Dev Tools. Screenshots below.

## Review

- @mistergone or @anselmbradford 

[Preview this PR without the whitespace changes](?w=0)

## Screenshot: Before

![screen shot 2017-07-25 at 2 32 03 pm](https://user-images.githubusercontent.com/702526/28588615-1af0617c-7149-11e7-801d-65d031270f52.png)


## Screenshot: After with CSS fix


![screen shot 2017-07-25 at 2 32 16 pm](https://user-images.githubusercontent.com/702526/28588616-1af2a55e-7149-11e7-800c-9d14b17833bd.png)


## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
