### PR TITLE
Fix line thickness for adjusted data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Charts for the Consumer Financial Protection Bureau",
   "main": "src/static/js/index.js",
   "scripts": {

--- a/src/static/css/cfpb-chart-builder.less
+++ b/src/static/css/cfpb-chart-builder.less
@@ -501,7 +501,7 @@
     // Seasonally adjusted 
     .highcharts-series-0 {
       .highcharts-graph {
-        stroke-width: 4px;
+        stroke-width: 3px;
       }
     }
 


### PR DESCRIPTION
Fixes line charts so the thickest line is only 3px in stroke (not 4 as in CSS responsive code by mistake).


## Review

- @contolini 
- @ajbush 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots

### Too thick
![screen shot 2017-07-25 at 3 47 28 pm](https://user-images.githubusercontent.com/702526/28590900-cfb7db32-7151-11e7-8e27-22cef7b9196b.png)


### Just right
![screen shot 2017-07-25 at 3 53 24 pm](https://user-images.githubusercontent.com/702526/28590899-cfb43efa-7151-11e7-8945-1818280f6f54.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
