### PR TITLE
WIP: Fix all the out of date colors by using cfgov-refresh version of cf-theme-overrides.less

### DIFF
--- a/src/css/cf-theme-overrides.less
+++ b/src/css/cf-theme-overrides.less
@@ -11,15 +11,14 @@
 @base-font-size-px:             16px;
 @base-line-height-px:           22px;
 @base-line-height:              unit(@base-line-height-px / @base-font-size-px);
-@mobile-max:                    599px;
-@tablet-min:                    600px;
 
 // Font variables
+@import (less) 'licensed-fonts.css';
 
-@webfont-regular:               'AvenirNextLTW01-Regular';
-@webfont-italic:                'AvenirNextLTW01-Italic';
-@webfont-medium:                'AvenirNextLTW01-Medium';
-@webfont-demi:                  'AvenirNextLTW01-Demi';
+@webfont-regular: 'AvenirNextLTW01-Regular';
+@webfont-italic: 'AvenirNextLTW01-Italic';
+@webfont-medium: 'AvenirNextLTW01-Medium';
+@webfont-demi: 'AvenirNextLTW01-Demi';
 
 // Color variables
 
@@ -29,24 +28,25 @@
 // a
 @link-text:                     @pacific;
 @link-underline:                @pacific;
-@link-text-visited:             @dark-teal;
-@link-underline-visited:        @dark-teal;
+@link-text-visited:             @teal;
+@link-underline-visited:        @teal;
 @link-text-hover:               @pacific-60;
 @link-underline-hover:          @pacific-60;
-@link-text-active:              @dark-navy;
-@link-underline-active:         @dark-navy;
+@link-text-active:              @navy;
+@link-underline-active:         @navy;
 
-// thead
-@thead-text:                    @white;
-@thead-bg:                      @dark-gray;
-@td-bg:                         @gray-5;
-@td-bg-alt:                     @gray-10;
+// tables
+@table-head-bg:                 @gray-10;
+@table-cell-bg:                 @white;
+@table-cell-bg_alt:             @gray-5;
+@table-scrolling-border:        @gray-40;
+@table-border:                  @gray;
 
 // input
 @input-bg:                      @white;
-@input-border:                  @gray-80;
+@input-border:                  @gray-60;
 @input-border-focus:            @pacific;
-@input-placeholder:             @gray-60;
+@input-placeholder:             @gray;
 
 // .figure__bordered
 @figure__bordered:              @gray-40;
@@ -61,12 +61,12 @@
 @btn-text:                      @white;
 @btn-bg:                        @pacific;
 @btn-bg-hover:                  @pacific-80;
-@btn-bg-active:                 @navy;
+@btn-bg-active:                 @navy-80;
 
 // .btn__secondary
 @btn__secondary-text:           @white;
-@btn__secondary-bg:             @gray-80;
-@btn__secondary-bg-hover:       @gray-60;
+@btn__secondary-bg:             @gray;
+@btn__secondary-bg-hover:       @gray-80;
 @btn__secondary-bg-active:      @dark-gray;
 
 // .btn__warning
@@ -76,16 +76,16 @@
 @btn__warning-bg-active:        @dark-red;
 
 // .btn__disabled
-@btn__disabled-text:            @gray-80;
-@btn__disabled-bg:              @gray-10;
-@btn__disabled-outline:         @gray-10;
+@btn__disabled-text:            @gray;
+@btn__disabled-bg:              @gray-20;
+@btn__disabled-outline:         @gray-20;
 
 // Sizing variables
 
 // .btn
 @btn-font-size:                 16px;
 @btn-v-padding:                 8px;
-@btn-v-padding-modifier-ie:     0.8;
+@btn-v-padding-modifier-ie:     .8;
 @super-btn-font-size:           18px;
 
 
@@ -105,14 +105,14 @@
 
 // .expandable__padded
 @expandable__padded-bg:         @gray-10;
-@expandable__padded-bg-hover:   @gray-10;
+@expandable__padded-bg-hover:   @gray-20;
 @expandable__padded-divider:    @gray-40;
 
 // .expandable-group
-@expandable-group_header-text:  @gray-80;
+@expandable-group_header-text:  @gray;
 @expandable-group_header-bg:    @gray-10;
 @expandable-group-bg:           @white;
-@expandable-group-divider:      @gray-40;
+@expandable-group-divider:      @gray-80;
 
 // Sizing variables
 
@@ -128,23 +128,11 @@
 // .error
 @input-error:                   @red;
 
-// warning
+// .warning
 @input-warning:                 @gold;
 
 // .success
 @input-success:                 @green;
-
-// .disabled
-@input-disabled:                 @gray-10;
-
-// .form-label-helper-text
-@label-helper:                  @dark-gray;
-
-// .form-l-inset_container
-@input-inset-bg:                @gray-10;
-
-// .form-l-inset_container.is-checked
-@input-inset-selected:          @pacific-20;
 
 // Sizing variables
 
@@ -155,12 +143,11 @@
 /* cf-grid
    ========================================================================== */
 
-@grid_box-sizing-polyfill-path: '/static/vendor/box-sizing-polyfill';
+@grid_box-sizing-polyfill-path: '../js';
 @grid_wrapper-width:            1230px;
 @grid_gutter-width:             30px;
 @grid_total-columns:            12;
 @grid_debug:                    false;
-
 
 /* cf-icons
    ========================================================================== */
@@ -176,18 +163,18 @@
 // Color variables
 
 // .block
-@block__bg:                     @gray-10;
+@block__border-top:             @gray-40;
+@block__border-right:           @gray-40;
+@block__border-bottom:          @gray-40;
+@block__border-left:            @gray-40;
 @block__border:                 @gray-40;
-@block__border-top:             @block__border;
-@block__border-right:           @block__border;
-@block__border-bottom:          @block__border;
-@block__border-left:            @block__border;
+@block__bg:                     @gray-5;
 
 // .content_main
 @content_main-border:           @gray-40;
 
 // .content_sidebar
-@content_sidebar-bg:            @gray-10;
+@content_sidebar-bg:            @gray-5;
 @content_sidebar-border:        @gray-40;
 
 // .content_bar
@@ -203,13 +190,26 @@
 @grid_column__left-divider:     @gray-40;
 
 
+// Hero variables
+
+// Sizing variables
+@hero-desktop-height:           285px;
+@hero-image-height:             195px;
+
+// Color variables
+@hero-bg:                       @gray-5;
+@hero-overlay-bg:               @gray;
+@hero-overlay-text:             white;
+@hero-overlay-cta:              @pacific-20;
+
+
 /* cf-pagination
    ========================================================================== */
 
 // Color variables
 
-@pagination-text:               @gray-80;
-@pagination-bg:                 @gray-10;
+@pagination-text:               @gray;
+@pagination-bg:                 @gray-20;
 
 // Sizing variables
 
@@ -222,40 +222,37 @@
 
 // Color variables
 
+// Running text elements
+
 // .pull-quote
 @pull-quote_body:               @black;
-@pull-quote_citation:           @gray-80;
+@pull-quote_citation:           @gray;
 
-// .micro-copy
-@micro-copy-text:               @gray-80;
+// .a-date
+@date:                          @gray;
 
-// .date
-@date-text:                     @gray-80;
+// Headings
 
-// .category-slug
-@category-slug-text:            @black;
-@category-slug-hover:           @link-text-hover;
+// .a-heading__icon
+@heading__icon:                 @black;
+@heading__icon__hover:          @link-text-hover;
 
-// .header-slug
-@header-slug-thin-border:       @gray-10;
-@header-slug-thick-border:      @green;
+// .a-heading__padded
+@heading__padded:               @dark-gray;
+@heading__padded_bg:            @gray-10;
+@heading__padded_border:        @gray-40;
 
-// .padded-header
-@padded-header-text:            @dark-gray;
-@padded-header-bg:              @gray-10;
-@padded-header-border:          @gray-40;
+// Headers
 
-// .fancy-slug
-@fancy-slug-text:               @black;
-@fancy-slug-bg:                 @white;
-@fancy-slug-border:             @gray-40;
+// .m-slug-header
+@slug-header_border__thin:      @gray-10;
+@slug-header_border__thick:     @green;
 
-// .meta-header
-@meta-header-border:            @gray-40;
+// .m-meta-header
+@meta-header_border:            @gray-40;
 
-// .jump-link
-@jump-link__bg:                 @gray-10;
-@jump-link__bg-border:          @gray-10;
+// Links
 
-// .list__branded
-@list__branded-bullet:          @green;
+// .a-link__jump
+@jump-link_bg:                  @gray-10;
+@jump-link_border:              @gray-40;


### PR DESCRIPTION
Fix all the out of date colors by using cfgov-refresh version of cf-theme-overrides.less.

This fixes bugs reported in the following places: 

- GHE/CFGOV/platform/issues/1040
- messed up table header colors in https://github.com/cfpb/cfgov-refresh/pull/3231
<img width="704" alt="screen shot 2017-08-10 at 10 37 39 am" src="https://user-images.githubusercontent.com/1280430/29178695-f28d7a6e-7db7-11e7-9fcd-4f2a26c13de4.png">


## Testing

in this project:
- run `gulp build` on this branch to make sure the vars compile to css correctly

to test this project in cfgov-refresh:
- Pull down this branch.
- `nvm use 8` in cfpb-chart-builder
- `npm link` in cfpb-chart-builder
- `cd ~/wherever/your/projects/are/cfgov-refresh/`
- `npm link cfpb-chart-builder`
- `gulp build`
- `./runserver`
- Verify that [this page](http://localhost:8000/about-us/the-bureau/) uses gray-5 (#f7f8f9) in the featured content module, and not gray-10 (#e7e8e9). see screenshots below for wrong and right gray examples.


[Preview this PR without the whitespace changes](?w=0)

## Screenshots
before
![screen shot 2017-08-09 at 1 25 51 pm](https://user-images.githubusercontent.com/702526/29192941-5890416e-7df1-11e7-8d2d-241d5a2ad7a6.png)


after
![screen shot 2017-08-09 at 1 26 23 pm](https://user-images.githubusercontent.com/702526/29192945-5d8dafd0-7df1-11e7-8183-bd8e037ba496.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
