### PR TITLE
Name Sauce tests after the git branch they run on

### DIFF
--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -6,6 +6,7 @@ var path = require('path');
 var serveStatic = require('serve-static');
 var request = require('request');
 var config = path.join(__dirname, './config.json');
+var child_process = require('child_process');
 
 var app = express();
 
@@ -63,7 +64,9 @@ function startSauce(err, process) {
             ["Windows 7", "chrome", ""]
         ],
         "url": "http://localhost:" + STATIC_SERVER_PORT + "/?ci_environment=" + CI_ENVIRONMENT,
-        "framework": "custom"
+        "framework": "custom",
+        "name": "Deborah Shoshlefski"
+        // child_process.execSync('git rev-parse --abbrev-ref HEAD').toString()
     }
   };
   request.post(opts, function(err, httpResponse, body) {

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -9,6 +9,7 @@ var config = path.join(__dirname, './config.json');
 var child_process = require('child_process');
 
 var app = express();
+var testName;
 
 if (!fs.existsSync(config) && !process.env.SAUCE_LABS_ACCESS_KEY) {
   console.error("Please define SAUCE_LABS_USERNAME and SAUCE_LABS_ACCESS_KEY in `test/config.js`.");
@@ -25,6 +26,13 @@ if (process.env.SAUCE_LABS_USERNAME && process.env.SAUCE_LABS_ACCESS_KEY) {
 } else {
   // Read creds from config file
   config = require(config);
+}
+
+if (process.env.TRAVIS_PULL_REQUEST) {
+  // testName = process.env.TRAVIS_BRANCH + ' ' + process.env.TRAVIS_JOB_NUMBER;
+  testName = 'Pull request #' + process.env.TRAVIS_PULL_REQUEST;
+} else {
+  testName = child_process.execSync('git rev-parse --abbrev-ref HEAD').toString();
 }
 
 var SAUCE_LABS_USERNAME = config.SAUCE_LABS_USERNAME,
@@ -65,7 +73,7 @@ function startSauce(err, process) {
         ],
         "url": "http://localhost:" + STATIC_SERVER_PORT + "/?ci_environment=" + CI_ENVIRONMENT,
         "framework": "custom",
-        "name": child_process.execSync('git rev-parse --abbrev-ref HEAD').toString()
+        "name": testName
     }
   };
   request.post(opts, function(err, httpResponse, body) {

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -28,8 +28,8 @@ if (process.env.SAUCE_LABS_USERNAME && process.env.SAUCE_LABS_ACCESS_KEY) {
   config = require(config);
 }
 
-if (process.env.TRAVIS_PULL_REQUEST !== false && process.env.TRAVIS_BRANCH && process.env.TRAVIS_JOB_NUMBER) {
-  testName = 'Pull request #' + process.env.TRAVIS_PULL_REQUEST + ', branch: ' + process.env.TRAVIS_BRANCH + ', Travis job #' + process.env.TRAVIS_JOB_NUMBER;
+if (process.env.TRAVIS_PULL_REQUEST !== false && process.env.TRAVIS_PULL_REQUEST_BRANCH && process.env.TRAVIS_JOB_NUMBER) {
+  testName = 'Pull request #' + process.env.TRAVIS_PULL_REQUEST + ', branch: ' + process.env.TRAVIS_PULL_REQUEST_BRANCH + ', Travis job #' + process.env.TRAVIS_JOB_NUMBER;
 } else {
   testName = child_process.execSync('git rev-parse --abbrev-ref HEAD').toString();
 }

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -65,8 +65,7 @@ function startSauce(err, process) {
         ],
         "url": "http://localhost:" + STATIC_SERVER_PORT + "/?ci_environment=" + CI_ENVIRONMENT,
         "framework": "custom",
-        "name": "Deborah Shoshlefski"
-        // child_process.execSync('git rev-parse --abbrev-ref HEAD').toString()
+        "name": child_process.execSync('git rev-parse --abbrev-ref HEAD').toString()
     }
   };
   request.post(opts, function(err, httpResponse, body) {

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -28,9 +28,8 @@ if (process.env.SAUCE_LABS_USERNAME && process.env.SAUCE_LABS_ACCESS_KEY) {
   config = require(config);
 }
 
-if (process.env.TRAVIS_PULL_REQUEST) {
-  // testName = process.env.TRAVIS_BRANCH + ' ' + process.env.TRAVIS_JOB_NUMBER;
-  testName = 'Pull request #' + process.env.TRAVIS_PULL_REQUEST;
+if (process.env.TRAVIS_PULL_REQUEST !== false && process.env.TRAVIS_BRANCH && process.env.TRAVIS_JOB_NUMBER) {
+  testName = 'Pull request #' + process.env.TRAVIS_PULL_REQUEST + ', branch: ' + process.env.TRAVIS_BRANCH + ', Travis job #' + process.env.TRAVIS_JOB_NUMBER;
 } else {
   testName = child_process.execSync('git rev-parse --abbrev-ref HEAD').toString();
 }


### PR DESCRIPTION
Gives Sauce tests a name in the UI, so you can associate a given test with a particular branch. Useful when reviewing PRs to confirm browser tests worked as expected.

## Additions

- pass name to Sauce Labs for each test
- get name from current git branch


## Testing

- run `npm test` and confirm tests executed at https://saucelabs.com/u/cct-sauce with the name of this git branch 
- check out a new branch and run `npm run browser-tests` to check that *that* branch name is the name of the tests


## Screenshots
![screen shot 2017-08-11 at 11 36 13 am](https://user-images.githubusercontent.com/702526/29220819-519b0ab2-7e8a-11e7-91b3-8e18ac7ad611.png)


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
