### PR TITLE
Add configurable tooltip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Optional. Chart's color scheme. Options: `blue`, `green`, `teal`, `navy`.
 Optional. Arbitrary metadata for your chart.
 For example, `bar` charts currently require a group key (e.g. `Number of Loans`) to filter data.
 
+**options.tooltipFormatter**: `Function`
+
+Optional. Function that returns HTML to format the chart's tooltip.
+See Highcharts' [tooltip.formatter](http://api.highcharts.com/highmaps/tooltip.formatter).
+
 ### `chart.update( options )`
 
 Update a CFPB chart.

--- a/src/js/charts/GeoMap.js
+++ b/src/js/charts/GeoMap.js
@@ -14,7 +14,7 @@ Highcharts.setOptions( {
 
 class GeoMap {
 
-  constructor( { el, metadata, data, color, title, desc, shapes } ) {
+  constructor( { el, metadata, data, color, title, desc, shapes, tooltipFormatter } ) {
 
     this.chartOptions = {
       credits: false,
@@ -44,16 +44,7 @@ class GeoMap {
         },
         screenReaderSectionFormatter: () => 'Map showing 30-day delinquent mortgages in the United States.'
       },
-      tooltip: {
-        useHTML: true,
-        formatter: function() {
-          var percent = Math.round( this.point.value * 10 ) / 10;
-          if ( !this.point.name ) {
-            return `${ percent }%`;
-          }
-          return `<div><h5>${ this.point.name }</h5><strong>${ percent }%<strong> mortgage delinquency rate</div>`;
-        }
-      },
+      tooltip: {},
       states: {
         hover: {
           brightness: 0
@@ -64,6 +55,13 @@ class GeoMap {
       },
       series: this.constructor.getSeries( data, shapes )
     };
+
+    if ( tooltipFormatter ) {
+      this.chartOptions.tooltip.useHTML = true;
+      this.chartOptions.tooltip.formatter = function() {
+        return tooltipFormatter( this.point, data[0].meta );
+      };
+    }
 
     this.chart = Highcharts.mapChart( el, Object.assign( {}, this.chartOptions ) );
   }

--- a/test/static/demo.js
+++ b/test/static/demo.js
@@ -21,7 +21,8 @@ const map = ccb.createChart( {
   source: 'mortgage-performance/map-data/30-89/metros/2009-01',
   type: 'geo-map',
   metadata: 'metros',
-  color: 'blue'
+  color: 'blue',
+  tooltipFormatter: point => `${ point.name }: ${ Math.round( point.value * 10 ) / 10 }%`
 } );
 
 const interval = setInterval( () => {

--- a/test/unit_tests/GeoMap_test.js
+++ b/test/unit_tests/GeoMap_test.js
@@ -41,6 +41,7 @@ describe( 'GeoMapComparison', () => {
       desc: 'chart description!',
       metadata: 'states',
       shapes: shapes,
+      tooltipFormatter: ( point, meta ) => [ point, meta.fips_type ],
       data: [
         {
           meta: {
@@ -79,6 +80,11 @@ describe( 'GeoMapComparison', () => {
         value: 5.7387478374837775
       }
     ] );
+  } );
+
+  it( 'should correctly set a tooltip formatter', () => {
+    expect( typeof geoMap.chart.options.tooltip.formatter ).to.equal( 'function' );
+    expect( geoMap.chart.options.tooltip.formatter()[1] ).to.equal( 'state' );
   } );
 
   it( 'should correctly set chart attributes', () => {


### PR DESCRIPTION
Lets the user pass a callback that returns HTML and will be used to format the tooltip of the Geo map. The callback is passed directly to Highchart's [tooltip.formatter()](http://api.highcharts.com/highmaps/tooltip.formatter) function.

Prior to this PR, the geo map's tooltip was hardcoded. It needs to be configurable to allow the MP pages to pass the national average mortgage delinquency percent to it.

## Additions

- New tooltipFormatter config option.

## Testing

1. Pull down this branch.
1. `npm test` and ensure all unit and browser tests pass.
1. `gulp build && gulp watch` and ensure the geo map on the demo page has tooltips when you hover over locations.

## Screenshots

![screen shot 2017-09-08 at 3 54 53 am](https://user-images.githubusercontent.com/1060248/30201641-822dd27a-9449-11e7-9d05-8e956e860354.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
