### PR TITLE
Properly handle null values in geo map

### DIFF
--- a/src/js/charts/GeoMap.js
+++ b/src/js/charts/GeoMap.js
@@ -83,7 +83,9 @@ class GeoMap {
     data = Object.keys( rows ).map( row => ( {
       fips: row,
       name: rows[row].name,
-      value: rows[row].value * 100
+      // Records with insufficient data are 'null' in the API.
+      // If the record's value is anything but a number, set it to -1.
+      value: typeof rows[row].value === 'number' ? rows[row].value * 100 : -1
     } ) );
 
     const series = [

--- a/src/js/utils/color-range.js
+++ b/src/js/utils/color-range.js
@@ -3,6 +3,11 @@
 const colors = {
   blue: [
     {
+      from: -1,
+      to: -1,
+      color: '#e7e8e9'
+    },
+    {
       from: 0,
       to: 0,
       color: '#dcdddf'
@@ -38,6 +43,11 @@ const colors = {
     }
   ],
   navy: [
+    {
+      from: -1,
+      to: -1,
+      color: '#e7e8e9'
+    },
     {
       from: 0,
       to: 0,

--- a/test/static/demo.js
+++ b/test/static/demo.js
@@ -22,7 +22,10 @@ const map = ccb.createChart( {
   type: 'geo-map',
   metadata: 'metros',
   color: 'blue',
-  tooltipFormatter: point => `${ point.name }: ${ Math.round( point.value * 10 ) / 10 }%`
+  tooltipFormatter: point => `<dl>
+    <dt>${ point.name }</dt>
+    <dd>${ point.value > 0 ? `${point.value}%` : 'Insufficient data' }</dd>
+  </dl>`
 } );
 
 const interval = setInterval( () => {


### PR DESCRIPTION
Null values were being erroneously coerced to 0. They are now set to -1 with a new color range in `color-range.js` of -1 to -1 set to light gray so that null locations on the map are correctly colored.

We'll soon need to move the color range object into a configurable setting (similar to what we did with the tooltip formatting function) because different maps will need different color ranges. Right now all our maps are 0% - 6% but that will change.

## Additions

- `-1 to -1` color range set to light gray.

## Removals

-

## Changes

- Set `null` values to -1 instead of 0 (which was the result of `null * 100`)
- Changed the demo page's tooltip to show "Insufficient data" for null values.

## Testing

- Pull down branch.
- `npm test` to ensure all automated tests pass.
- `gulp watch` to open demo page and visually inspect the geo map.

## Screenshots

![screen shot 2017-09-11 at 12 45 56 pm](https://user-images.githubusercontent.com/1060248/30286331-3221bcee-96ef-11e7-91df-c66f2eaacd10.png)

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
