### PR TITLE
Update tooltip formatter when chart is updated

### DIFF
--- a/src/js/charts/GeoMap.js
+++ b/src/js/charts/GeoMap.js
@@ -117,6 +117,14 @@ class GeoMap {
     if ( newOptions.data ) {
       newOptions.series = this.constructor.getSeries( newOptions.data, newOptions.shapes );
     }
+    if ( newOptions.tooltipFormatter ) {
+      newOptions.tooltip = {
+        useHTML: true,
+        formatter: function() {
+          return newOptions.tooltipFormatter( this.point, newOptions.data[0].meta );
+        }
+      };
+    }
     // Merge the old chart options with the new ones
     Object.assign( this.chartOptions, newOptions );
     this.chart.update( this.chartOptions, true, true );

--- a/test/unit_tests/GeoMap_test.js
+++ b/test/unit_tests/GeoMap_test.js
@@ -1,4 +1,4 @@
-/* global before describe it */
+/* global before beforeEach describe it */
 
 'use strict';
 
@@ -35,7 +35,7 @@ let geoMap;
 
 describe( 'GeoMapComparison', () => {
 
-  before( () => {
+  beforeEach( () => {
     geoMap = new GeoMap( {
       el: 'el',
       desc: 'chart description!',
@@ -85,6 +85,30 @@ describe( 'GeoMapComparison', () => {
   it( 'should correctly set a tooltip formatter', () => {
     expect( typeof geoMap.chart.options.tooltip.formatter ).to.equal( 'function' );
     expect( geoMap.chart.options.tooltip.formatter()[1] ).to.equal( 'state' );
+  } );
+
+  it( 'should correctly update a tooltip formatter', () => {
+    geoMap.update( {
+      data: [ {
+        meta: {
+          date: '2020-01-01',
+          fips_type: 'state'
+        },
+        data: {
+          18: {
+            value: 0.036920278872385574,
+            name: 'California'
+          },
+          22: {
+            value: 0.05738747837483777,
+            name: 'Delaware'
+          }
+        }
+      } ],
+      tooltipFormatter: ( point, meta ) => [ point, meta.date ]
+    } );
+    expect( typeof geoMap.chart.options.tooltip.formatter ).to.equal( 'function' );
+    expect( geoMap.chart.options.tooltip.formatter()[1] ).to.equal( '2020-01-01' );
   } );
 
   it( 'should correctly set chart attributes', () => {


### PR DESCRIPTION
The tooltip formatting function was only being passed to Highcharts on chart initialization so subsequent updates to it were being ignored. With the Mortgage Performance charts this was causing the [national average to not be updated](https://github.com/cfpb/cfgov-refresh/pull/3329#issuecomment-328559015).

## Additions

- Update `tooltipFormatter` when `chart.update()` is called.

## Removals

-

## Changes

-

## Testing

- Pull down branch.
- `npm test` to ensure all automated tests pass.
- `gulp watch` to open demo page and visually inspect the geo map.

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
