### PR TITLE
Remove extra border from top of line comparison charts

### DIFF
--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -43,7 +43,8 @@
 
   }
 
-  &[data-chart-type="tile_map"]:after  {
+  &[data-chart-type="tile_map"]:after,
+  &[data-chart-type='line-comparison']:after {
 
     display: none;
 


### PR DESCRIPTION
There is a default line above footnotes that's not needed for line comparison charts, and is currently appearing in the wrong location.

## Changes

- Don't display `&[data-chart-type='line-comparison']:after` 

## Testing

- Pull down branch.
- `./setup.sh`
- `npm test` to ensure all tests pass.
- `gulp watch` to pop open the demo page to see the new legend location for comparative line charts (and check that the legend hasn't changed for regular line charts).

## Review

- @contolini

## Screenshots

### Current

![screen shot 2017-09-26 at 9 12 32 pm](https://user-images.githubusercontent.com/1183435/30891418-4258f618-a301-11e7-8899-9ff306e3da9f.png)

### Changed

![screen shot 2017-09-26 at 9 12 43 pm](https://user-images.githubusercontent.com/1183435/30891420-47b53b58-a301-11e7-9d94-8f02b12d644b.png)

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
