### PR TITLE
Shift the line comparison chart back to the right

### DIFF
--- a/src/js/charts/LineChartComparison.js
+++ b/src/js/charts/LineChartComparison.js
@@ -81,8 +81,8 @@ class LineChartComparison {
 
     this.chartOptions = {
       chart: {
-        marginLeft: 0,
-        marginTop: 50,
+        marginRight: 0,
+        marginTop: 100,
         zoomType: 'none',
         animation: false
       },


### PR DESCRIPTION
In an earlier commit, I accidentally moved this chart type over to the
right and cut off the Y axis. Moving it back to its former values.

## Changes

- Restore previous values for margins on line comparison chart

## Testing

- Pull down branch.
- `./setup.sh`
- `npm test` to ensure all tests pass.
- `gulp watch` to pop open the demo page to see the new legend location for comparative line charts (and check that the legend hasn't changed for regular line charts).

## Review

- @contolini 
- @ajbush 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
