### PR TITLE
Store AJAX requests in session storage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,16 @@
       "integrity": "sha512-6qLZpfQFO/g5Ns2e7RsW6brk0Q6Xzwiw7kVVU/XiQNOiJXSojhX76GP457PBYIsNMH2WfcGgcnZB4awFDHrwpA==",
       "dev": true
     },
+    "JSONStream": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
+      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
+      "dev": true,
+      "requires": {
+        "jsonparse": "1.3.1",
+        "through": "2.3.8"
+      }
+    },
     "abab": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.3.tgz",
@@ -1474,9 +1484,9 @@
       "integrity": "sha1-+GzWzvT1MAyOY+B6TVEvZfv/RTE=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "defined": "1.0.0",
-        "JSONStream": "1.3.1",
         "through2": "2.0.3",
         "umd": "3.0.1"
       }
@@ -1567,6 +1577,7 @@
       "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "assert": "1.4.1",
         "browser-pack": "6.0.2",
         "browser-resolve": "1.11.2",
@@ -1588,7 +1599,6 @@
         "https-browserify": "0.0.1",
         "inherits": "2.0.3",
         "insert-module-globals": "7.0.1",
-        "JSONStream": "1.3.1",
         "labeled-stream-splicer": "2.0.0",
         "module-deps": "4.1.1",
         "os-browserify": "0.1.2",
@@ -5575,14 +5585,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -5591,6 +5593,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -8069,10 +8079,10 @@
       "integrity": "sha1-wDv04BywhtW15azorQr+eInWOMM=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "combine-source-map": "0.7.2",
         "concat-stream": "1.5.2",
         "is-buffer": "1.1.5",
-        "JSONStream": "1.3.1",
         "lexical-scope": "1.2.0",
         "process": "0.11.10",
         "through2": "2.0.3",
@@ -8849,16 +8859,6 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
       "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.1.tgz",
-      "integrity": "sha1-cH92HgHa6eFvG8+TcDt4xwlmV5o=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "jsprim": {
       "version": "1.4.1",
@@ -9927,6 +9927,7 @@
       "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
       "dev": true,
       "requires": {
+        "JSONStream": "1.3.1",
         "browser-resolve": "1.11.2",
         "cached-path-relative": "1.0.1",
         "concat-stream": "1.5.2",
@@ -9934,7 +9935,6 @@
         "detective": "4.5.0",
         "duplexer2": "0.1.4",
         "inherits": "2.0.3",
-        "JSONStream": "1.3.1",
         "parents": "1.0.1",
         "readable-stream": "2.3.3",
         "resolve": "1.4.0",
@@ -12323,15 +12323,6 @@
       "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
@@ -12341,6 +12332,15 @@
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {
@@ -13815,12 +13815,6 @@
             "read-pkg": "2.0.0"
           }
         },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        },
         "string-width": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -13830,6 +13824,12 @@
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
           }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "4.0.0",

--- a/src/js/utils/get-data.js
+++ b/src/js/utils/get-data.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ajax = require( 'xdr' );
+const cache = require('./session-storage');
 
 // IE9 doesn't allow XHR from different protocols so until we get files.cf.gov
 // onto HTTPS we need to choose how we use S3.
@@ -20,11 +21,17 @@ const getData = sources => {
     if ( url.indexOf( 'http' ) !== 0 && url.indexOf( '/' ) !== 0 ) {
       url = DATA_SOURCE_BASE + url.replace( '.csv', '.json' );
     }
-    ajax( { url: url, type: 'json' }, function( resp ) {
+    if ( cache.getItem( url ) ) {
+      // Ensure UI isn't blocked when loading large shapefiles by making
+      // cache resolver asynchronous https://stackoverflow.com/q/10180391
+      return setTimeout( () => resolve( cache.getItem( url ) ), 0 );
+    }
+    return ajax( { url: url, type: 'json' }, function( resp ) {
       if ( resp.error ) {
         reject( resp.error );
         return;
       }
+      cache.setItem( url, resp.data );
       resolve( resp.data );
     } );
   } ) );

--- a/src/js/utils/map-shapes.js
+++ b/src/js/utils/map-shapes.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const ajax = require( './get-data' );
+const cache = require('./session-storage');
 
 let DATA_SOURCE_BASE = window.location.protocol.indexOf( 'https' ) === -1 ?
                       '//files.consumerfinance.gov/data/' :
@@ -14,13 +15,13 @@ let shapes = {
 
 const fetchShapes = geoType => {
   // If the shapes have already been downloaded resolve the promise immediately.
-  if ( typeof shapes[geoType] === 'object' ) {
-    return Promise.resolve( shapes[geoType] );
+  if ( cache.getItem( `shapes-${ geoType }` ) ) {
+    return Promise.resolve( cache.getItem( `shapes-${ geoType }` ) );
   }
   // Otherwise, download the shapes and cache them for future requests.
   const promise = ajax( shapes[geoType] );
   promise.then( data => {
-    shapes[geoType] = data;
+    cache.setItem( `shapes-${ geoType }`, data );
   } );
   return promise;
 };

--- a/src/js/utils/session-storage.js
+++ b/src/js/utils/session-storage.js
@@ -1,0 +1,109 @@
+/* ==========================================================================
+   Web Storage proxy utility.
+
+   An interface for interacting with web storage
+   (local storage and session storage).
+   Note: values stored in local storage are not accessible from session storage
+   and vice versa. They both work on different objects within the browser.
+   If web storage is not available, values are dumped into an object literal
+   to keep the fuctionality of the API, but will not be saved across sessions.
+   ========================================================================= */
+
+'use strict';
+
+// Default storage type.
+var _storage;
+
+/**
+ * Set an item value specified by the key in web storage.
+ * @param {string} key The key for the value.
+ * @param {string} value The value to store.
+ * @param {Object} storage (Optional)
+ *   Use non-persistent storage (sessionStorage)
+ *   or persistent storage (localStorage).
+ * @returns {string} The value set in web storage.
+ */
+function setItem( key, value, storage ) {
+  value = JSON.stringify( value );
+  storage = _getStorageType( storage );
+  if ( storage.setItem ) {
+    storage.setItem( key, value );
+  } else {
+    storage[key] = value;
+  }
+
+  return value;
+}
+
+/**
+ * Get an item value specified by the key in web storage.
+ * @param {string} key The key for the value.
+ * @param {Object} storage (Optional)
+ *   Use non-persistent storage (sessionStorage)
+ *   or persistent storage (localStorage).
+ * @returns {string} The value set in web storage.
+ */
+function getItem( key, storage ) {
+  storage = _getStorageType( storage );
+  return storage.getItem ? JSON.parse( storage.getItem( key ) ) : JSON.parse( storage[key] );
+}
+
+/**
+ * Remove an item specified by the key.
+ * @param {string} key The key for the value.
+ * @param {Object} storage (Optional)
+ *   Use non-persistent storage (sessionStorage)
+ *   or persistent storage (localStorage).
+ * @returns {boolean} Returns true if the item existed and it was
+ *   removed. Returns false if the item didn't exist to begin with.
+ */
+function removeItem( key, storage ) {
+  storage = _getStorageType( storage );
+  var returnVal = true;
+
+  if ( !getItem( key, storage ) ) {
+    returnVal = false;
+  }
+
+  if ( returnVal ) {
+    if ( storage.removeItem ) {
+      storage.removeItem( key );
+    } else {
+      delete storage[key];
+    }
+  }
+
+  return returnVal;
+}
+
+/**
+ * Internal function for whether to use local or session storage.
+ * @param {Object} storage
+ *   Use non-persistent storage (sessionStorage)
+ *   or persistent storage (localStorage).
+ * @returns {Object} A local storage or session storage instance.
+ */
+function _getStorageType( storage ) {
+  // Use default setting if none is provided.
+  if ( typeof storage !== 'object' ) {
+    if ( typeof _storage === 'undefined' ) {
+      try {
+        storage = window.sessionStorage;
+      } catch ( err ) {
+        // SecurityError was thrown if cookies are off.
+        storage = {};
+      }
+    } else {
+      storage = _storage;
+    }
+  }
+
+  return storage;
+}
+
+// Expose public methods.
+module.exports = {
+  setItem:    setItem,
+  getItem:    getItem,
+  removeItem: removeItem
+};

--- a/test/unit_tests/utils/get-data_test.js
+++ b/test/unit_tests/utils/get-data_test.js
@@ -15,6 +15,11 @@ const getData = ( url, data ) => {
   mock( 'xdr', ( opts, cb ) => {
     cb( { data: data } );
   } );
+  mock( '../../../src/js/utils/session-storage', {
+    getItem: () => ( { foo: 'bar' } ),
+    setItem: () => ( { foo: 'bar' } ),
+    removeItem: () => ( { foo: 'bar' } )
+  } );
   return mock.reRequire( '../../../src/js/utils/get-data' )( url );
 };
 


### PR DESCRIPTION
Prevent unnecessary XHRs by caching them in session storage. If session storage is unavailable, store them in memory. The caching module is stolen from [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/blob/960c6ee91894e1fc91da5bb7b08ea1dcfdc4e81e/cfgov/unprocessed/js/modules/util/web-storage-proxy.js).

Session storage is cleared as soon as the browser/tab is closed so there's no risk of stale cache.

## Changes

- Cache requests (including map shapefiles) in session storage.

## Testing

- Pull down branch.
- `gulp watch`
- In a new Chrome tab, open dev tools and click on the `Network` tab. Filter so it's only showing `XHR` requests.
- Go to http://localhost:3000/ and you'll see lots of JSON and shapefiles XHR activity.
- Reload the page and there will be no XHR activity (with the exception of Browser Sync).

## Screenshots

Initial chart requests:

<img width="1395" alt="screen shot 2017-10-16 at 3 10 31 am" src="https://user-images.githubusercontent.com/1060248/31599410-42b4ff20-b220-11e7-8602-0157da49ca4d.png">

Subsequent ones come from session storage (requests below are just Browser Sync):

<img width="1401" alt="screen shot 2017-10-16 at 3 10 54 am" src="https://user-images.githubusercontent.com/1060248/31599430-574d2520-b220-11e7-8fea-7ebb99488fd7.png">

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
