### PR TITLE
Add ability to specify y-axis label on line chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Add a `div` with a class of `cfpb-chart` and the following data attributes to yo
 <div class="cfpb-chart"
      data-chart-type="line"
      data-chart-title="Number of Originations (in millions)"
+     data-chart-y-axis-label="Volume of Originations (in billons)"
      data-chart-description="Auto loan originations decreased in 2016."
      data-chart-color="green"
      data-chart-metadata="Number of Loans"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Charts for the Consumer Financial Protection Bureau",
   "main": "src/js/index.js",
   "scripts": {

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -49,18 +49,29 @@ function _getYAxisUnits( array ) {
 /**
  * _getYAxisLabel - Get the text of the y-axis title
  *
- * @param  {array} array  An array of values to check
+ * @param  {array} chartData  An array of values to check
+ * @param  {sting} yAxisLabel  A string to use for the y-axis label.
  * @returns {string}    Appropriate y-axis title
  */
-function _getYAxisLabel( array ) {
-  var value = _getFirstNumber( array );
-  if ( !value ) {
-    return value;
+function _getYAxisLabel( chartData, yAxisLabel ) {
+  var term = 'Number';
+  var unit = 'millions';
+  var firstChartNumber = _getFirstNumber( chartData );
+
+  if ( yAxisLabel ) {
+    return yAxisLabel;
   }
-  if ( value % 1000000000 < value ) {
-    return 'Volume';
+
+  if ( !firstChartNumber ) {
+    return firstChartNumber;
   }
-  return 'Number';
+
+  if ( firstChartNumber % 1000000000 < firstChartNumber ) {
+    term = 'Volume';
+    unit = 'billions';
+  }
+
+  return term + ' of originations (in ' + unit + ')';
 }
 
 /**
@@ -168,7 +179,7 @@ function LineChart( props ) {
       opposite: false,
       className: 'axis-label',
       title: {
-        text: _getYAxisLabel( props.data.adjusted ) + ' of originations (in ' + _getYAxisUnits( props.data.adjusted ) + ')',
+        text: _getYAxisLabel( props.data.adjusted, props.yAxisLabel ),
         offset: 0,
         reserveSpace: false
       },

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -100,6 +100,7 @@ function _createCharts() {
     new Chart( {
       el: chart,
       title: chart.getAttribute( 'data-chart-title' ),
+      yAxisLabel: chart.getAttribute( 'data-chart-y-axis-label' ),
       type: chart.getAttribute( 'data-chart-type' ),
       color: chart.getAttribute( 'data-chart-color' ),
       metadata: chart.getAttribute( 'data-chart-metadata' ),


### PR DESCRIPTION
Add ability to specify y-axis label on line chart


## Changes

- Modified `src/js/charts/LineChart.js` and `src/js/index.js` to add the ability to specify the y-axis label using the data attribute.

## Testing

- Run `npm test`.

## Review

- @user

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

- Write tests for the PR. 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
