### PR TITLE
Show a Y-axis label on the top grid lines of charts (and fix a Mortgage Performance color bug)

### DIFF
--- a/src/js/charts/BarChart.js
+++ b/src/js/charts/BarChart.js
@@ -92,6 +92,7 @@ function BarChart( props ) {
       } ]
     },
     yAxis: {
+      showLastLabel: true,
       opposite: false,
       title: {
         text: 'Year-over-year change (%)',

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -176,6 +176,7 @@ function LineChart( props ) {
       } ]
     },
     yAxis: {
+      showLastLabel: true,
       opposite: false,
       className: 'axis-label',
       title: {

--- a/src/js/charts/LineChartComparison.js
+++ b/src/js/charts/LineChartComparison.js
@@ -130,6 +130,7 @@ class LineChartComparison {
         }
       },
       yAxis: {
+        showLastLabel: true,
         min: 0,
         opposite: false,
         className: 'axis-label',

--- a/test/index.html
+++ b/test/index.html
@@ -42,7 +42,7 @@
                 <hr>
                 <!-- This chart's sources start with a slash indicating it wants to load its data from the same domain -->
                 <div class="cfpb-chart"
-                     data-chart-color="green"
+                     data-chart-color="navy"
                      data-chart-description="This is the chart description."
                      data-chart-source="/sample_data/mortgage-performance/time-series/90/12031;/sample_data/mortgage-performance/time-series/90/national"
                      data-chart-title="90-day Mortgage Delinquencies"


### PR DESCRIPTION
This PR makes sure that there is a label on the top grid line of the charts generated for line, line comparison, and bar charts. On our particular charts, [Highcharts defaults this setting to `false`](https://api.highcharts.com/highcharts/yAxis.showLastLabel), but we can set the API value to `true`.

In addition, this corrects a bug where the test chart for 90 day delinquencies was set to use the color `green` instead of `navy`.

Internal bug reports:
- https://[GHE]/CFGOV/mortgage-performance/issues/220 (top line label)
- https://[GHE]/CFGOV/data-research/issues/613 (top line label)
- https://[GHE]/CFGOV/mortgage-performance/issues/216 (correct color)

## Additions

- Set `yAxis.showLastLabel` to `true` for line comparison charts
- Set `yAxis.showLastLabel` to `true` for line charts
- Set `yAxis.showLastLabel` to `true` for bar charts

## Changes

- Change 90 day delinquency test chart to use Navy instead of Green

## Screenshots

### Current demo with code in production

![screen shot 2017-10-30 at 12 58 28 pm](https://user-images.githubusercontent.com/1183435/32184299-393e72f2-bd72-11e7-91d0-a7d17d767d49.png)

### Demo with code from this branch

![screen shot 2017-10-30 at 12 57 29 pm](https://user-images.githubusercontent.com/1183435/32184314-3ebfa192-bd72-11e7-8c64-7dfc183b789a.png)

## Testing

- Pull down branch.
- ./setup.sh
- `npm test` to ensure all tests pass.
- `gulp watch` to pop open the demo page and see that:
    - a) labels are now appearing on the top grid lines, and
    - b) that the second line comparison chart is using Navy instead of Green.

## Review

- @contolini 
- @cfarm 
- @sebworks 

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
