### PR TITLE
Fix for inline highcharts import statement

### DIFF
--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -1,4 +1,4 @@
-@import (inline) 'highcharts.css';
+@import (less) 'highcharts.css';
 @import 'cf-core.less';
 
 // Chart colors


### PR DESCRIPTION
Fix for inline highcharts import statement

## Changes

- Modified `src/css/cfpb-chart-builder.less` so that the css is minified.


[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
