### PR TITLE
Fix for inline highcharts import statement 

### DIFF
--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -1,5 +1,5 @@
-@import (inline) 'highcharts.css';
-@import 'cf-core.less';
+@import (less) 'highcharts.css';
+@import (less) 'cf-core.less';
 
 // Chart colors
 


### PR DESCRIPTION
Fixes #84 

## Changes

- Adds `(less)` import keyword to CSS imports.

## Testing

- `./setup.sh` should pass.

## @contolini @cfarm, can one of you release this after this goes in?