### PR TITLE
Fix for Babel function hoisting

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "3.1.1",
+  "version": "3.2.1",
   "description": "Charts for the Consumer Financial Protection Bureau",
   "main": "src/js/index.js",
   "scripts": {

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -11,12 +11,6 @@ var process = require( './utils/process-json' );
 var ajax = require( './utils/get-data' );
 var shapes = require( './utils/map-shapes' );
 
-/***
-* When the document is ready, the code for cfpb-chart-builder seeks out chart
-* blocks and generates charts inside the designated elements.
-*/
-documentReady( _createCharts );
-
 class Chart {
 
   constructor( chartOptions ) {
@@ -108,6 +102,13 @@ function _createCharts() {
     } );
   }
 }
+
+/***
+* When the document is ready, the code for cfpb-chart-builder seeks out chart
+* blocks and generates charts inside the designated elements.
+*/
+documentReady( _createCharts );
+
 
 var charts = {
   createChart: _createChart,


### PR DESCRIPTION
Babel is wrapping in classes in an IIFE and document ready command is invoked immediately, thus holiday joy. 

## Changes

- Modified code to move `documentReady` to the bottom of the file and give Santa time to execute.


## Review

- @Scotchester 
- @hillaryj 
- @anselmbradford 

[Preview this PR without the whitespace changes](?w=0)

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
