### PR TITLE
Remove review section in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,12 +16,6 @@ Short description explaining the high-level reason for the pull request
 
 -
 
-## Review
-
-- @user
-
-[Preview this PR without the whitespace changes](?w=0)
-
 ## Screenshots
 
 


### PR DESCRIPTION
Since GH now has a reviewers section in the upper-right, the review section in the PR template is no longer needed.

## Removals

- Review section in PR template.
