### PR TITLE
Removes redundant task

### DIFF
--- a/gulp/tasks/connect.js
+++ b/gulp/tasks/connect.js
@@ -12,5 +12,3 @@ gulp.task( 'connect', function() {
     }
   } );
 } );
-
-gulp.task( 'default', [ 'connect' ] );


### PR DESCRIPTION
Default task defined twice: [here](https://github.com/cfpb/cfpb-chart-builder/blob/master/gulp/tasks/connect.js#L16) and [here](https://github.com/cfpb/cfpb-chart-builder/blob/master/gulp/tasks/default.js#L3)

Fixes #99

## Removals

- default gulp task in connect.js.


## Testing

- `gulp` should work as before.
