### PR TITLE
Revert ES6 variables in test-runner for IE9

### DIFF
--- a/test/test-runner.js
+++ b/test/test-runner.js
@@ -19,8 +19,11 @@ if ( !( window.console && console.log ) ) {
 }
 
 function isCI( name, url ) {
-  let regex = new RegExp( '[?&]ci_environment(=([^&#]*)|&|#|$)' ),
-      results = regex.exec( window.location.href );
+  // TODO: Convert variables to const when IE9 support is removed.
+  // eslint-disable-next-line no-var
+  var regex = new RegExp( '[?&]ci_environment(=([^&#]*)|&|#|$)' );
+  // eslint-disable-next-line no-var
+  var results = regex.exec( window.location.href );
   if ( !results ) return false;
   if ( !results[2] ) return false;
   return true;
@@ -28,7 +31,8 @@ function isCI( name, url ) {
 
 // Catch all errors and report them to Sauce Labs.
 function getSaucy() {
-  const errors = [];
+  // eslint-disable-next-line no-var
+  var errors = [];
   window.onerror = function( message, url, lineNumber ) {
     errors.push( {
       name: 'Smoke test',


### PR DESCRIPTION
test-runner.js runs without any processing in the demo for testing purposes. This reverts and ignores from the linter the variables that were converted to const and let, so that the charts render in IE9

## Changes

- Set variables to `var` and ignore linter rules till IE9 support is dropped.

## Testing

- `gulp build && gulp watch` should work in IE9.
