### PR TITLE
Use https URL for aws files

### DIFF
--- a/src/js/utils/get-data.js
+++ b/src/js/utils/get-data.js
@@ -1,15 +1,9 @@
 const ajax = require( 'xdr' );
 const cache = require( './session-storage' );
 
-/* IE9 doesn't allow XHR from different protocols so we check what protocol
-   is being used and accommodate it . */
-let DATA_SOURCE_BASE = window.location.protocol.indexOf( 'https' ) === -1 ?
-  // HTTP-only endpoint
-  '//files.consumerfinance.gov.s3.amazonaws.com/data/' :
-  // HTTPS-only endpoint
-  '//files.consumerfinance.gov/data/';
+let DATA_SOURCE_BASE = '//files.consumerfinance.gov/data/';
 
-// Let browsers override the data source root (useful for localhost testing)
+// Let browsers override the data source root (useful for localhost testing).
 DATA_SOURCE_BASE = window.CFPB_CHART_DATA_SOURCE_BASE || DATA_SOURCE_BASE;
 
 const getData = sources => {

--- a/src/js/utils/get-data.js
+++ b/src/js/utils/get-data.js
@@ -1,7 +1,7 @@
 const ajax = require( 'xdr' );
 const cache = require( './session-storage' );
 
-let DATA_SOURCE_BASE = '//files.consumerfinance.gov/data/';
+let DATA_SOURCE_BASE = 'https://files.consumerfinance.gov/data/';
 
 // Let browsers override the data source root (useful for localhost testing).
 DATA_SOURCE_BASE = window.CFPB_CHART_DATA_SOURCE_BASE || DATA_SOURCE_BASE;

--- a/src/js/utils/map-shapes.js
+++ b/src/js/utils/map-shapes.js
@@ -1,13 +1,7 @@
 const ajax = require( './get-data' );
 const cache = require( './session-storage' );
 
-/* IE9 doesn't allow XHR from different protocols so we check what protocol
-   is being used and accommodate it . */
-const DATA_SOURCE_BASE = window.location.protocol.indexOf( 'https' ) === -1 ?
-  // HTTP-only endpoint
-  '//files.consumerfinance.gov.s3.amazonaws.com/data/' :
-  // HTTPS-only endpoint
-  '//files.consumerfinance.gov/data/';
+const DATA_SOURCE_BASE = '//files.consumerfinance.gov/data/';
 
 const shapes = {
   states: `${ DATA_SOURCE_BASE }mortgage-performance/meta/us-states.geo.json`,

--- a/src/js/utils/map-shapes.js
+++ b/src/js/utils/map-shapes.js
@@ -1,7 +1,7 @@
 const ajax = require( './get-data' );
 const cache = require( './session-storage' );
 
-const DATA_SOURCE_BASE = '//files.consumerfinance.gov/data/';
+const DATA_SOURCE_BASE = 'https://files.consumerfinance.gov/data/';
 
 const shapes = {
   states: `${ DATA_SOURCE_BASE }mortgage-performance/meta/us-states.geo.json`,


### PR DESCRIPTION
See [GHE]/CFGOV/platform/issues/2920

## Changes

- Removes `http` URL from get-data and map-shapes script.

## Testing

- Run `gulp build && gulp watch` charts should load in IE9.
- Check charts in cfgov-refresh, by
 1. checking this branch out in `cfpb-chart-builder`
 2. Copy local `cfpb-chart-builder` directory into `node_modules` locally in cfgov-refresh repo.
 3. Remove `no-js` from cfgov-refresh https://github.com/cfpb/cfgov-refresh/blob/master/cfgov/jinja2/v1/_layouts/base-common.html#L29
 3. Run cfgov-refresh server.
 4. Visit e.g. /data-research/consumer-credit-trends/auto-loans/origination-activity/ in IE9 and check that charts load.
