### PR TITLE
Add three new colors for line charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,9 +2543,9 @@
       }
     },
     "cf-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.7.0.tgz",
-      "integrity": "sha512-NsYKB4NAFyy/DMsL/ZS/HMxBat9RtNSPs/bwvLeenrPIC3H+lgj/9j5QxZ1eQu7SjbDbrF2MjcP4SpV5KWKJLQ==",
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.10.0.tgz",
+      "integrity": "sha512-PNWKMRTs3/yu0uS038QBt+e2Ivgp7hltQJi4Y4rP8+W/ayaHu5qQzf25ow5+E6fWYCY3bzNPgLqD2PR1mZhxsg==",
       "requires": {
         "normalize-css": "2.3.1",
         "normalize-legacy-addon": "0.1.0"
@@ -2565,7 +2565,7 @@
       "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-4.2.2.tgz",
       "integrity": "sha512-SNtrRwtMKlrHxUan/dTAe35Bh+7IEsgRwIpVchsYLsfam72zkjhUYa+/+EpbHDR+C2AbTNuFboVLu3hRvcJNcw==",
       "requires": {
-        "cf-core": "4.7.0"
+        "cf-core": "4.10.0"
       }
     },
     "cf-layout": {
@@ -2573,7 +2573,7 @@
       "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.8.0.tgz",
       "integrity": "sha512-6oAj9gTt291aqSOKziYJprfn0SlUOu3ZAaXOAXwLBpv3eEUYj1x6n6d9BdmaKOU/x0D8jGpi0P1GkJwIOsJ0og==",
       "requires": {
-        "cf-core": "4.7.0",
+        "cf-core": "4.10.0",
         "cf-grid": "4.2.4"
       }
     },
@@ -2582,7 +2582,7 @@
       "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.9.0.tgz",
       "integrity": "sha512-1rJHip5pen7czfLbtsHnKODG6ZmSI1ntw/9lJqgxoDVK5Q4pzcl0WgOGkwLJlImJg2zzGLRkdqfeZtVORt4TmQ==",
       "requires": {
-        "cf-core": "4.7.0",
+        "cf-core": "4.10.0",
         "cf-icons": "4.2.2"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -2543,9 +2543,9 @@
       }
     },
     "cf-core": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.6.0.tgz",
-      "integrity": "sha512-y0M5oFfpwZxnmSzwPv8nPg7++82AdxkMQi0woQseReRBSdzPMdBL+9JHSZUyojag2mHuUwhvp80HtGwZbdVBUg==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/cf-core/-/cf-core-4.7.0.tgz",
+      "integrity": "sha512-NsYKB4NAFyy/DMsL/ZS/HMxBat9RtNSPs/bwvLeenrPIC3H+lgj/9j5QxZ1eQu7SjbDbrF2MjcP4SpV5KWKJLQ==",
       "requires": {
         "normalize-css": "2.3.1",
         "normalize-legacy-addon": "0.1.0"
@@ -2565,7 +2565,7 @@
       "resolved": "https://registry.npmjs.org/cf-icons/-/cf-icons-4.2.2.tgz",
       "integrity": "sha512-SNtrRwtMKlrHxUan/dTAe35Bh+7IEsgRwIpVchsYLsfam72zkjhUYa+/+EpbHDR+C2AbTNuFboVLu3hRvcJNcw==",
       "requires": {
-        "cf-core": "4.6.0"
+        "cf-core": "4.7.0"
       }
     },
     "cf-layout": {
@@ -2573,7 +2573,7 @@
       "resolved": "https://registry.npmjs.org/cf-layout/-/cf-layout-4.8.0.tgz",
       "integrity": "sha512-6oAj9gTt291aqSOKziYJprfn0SlUOu3ZAaXOAXwLBpv3eEUYj1x6n6d9BdmaKOU/x0D8jGpi0P1GkJwIOsJ0og==",
       "requires": {
-        "cf-core": "4.6.0",
+        "cf-core": "4.7.0",
         "cf-grid": "4.2.4"
       }
     },
@@ -2582,7 +2582,7 @@
       "resolved": "https://registry.npmjs.org/cf-typography/-/cf-typography-4.9.0.tgz",
       "integrity": "sha512-1rJHip5pen7czfLbtsHnKODG6ZmSI1ntw/9lJqgxoDVK5Q4pzcl0WgOGkwLJlImJg2zzGLRkdqfeZtVORt4TmQ==",
       "requires": {
-        "cf-core": "4.6.0",
+        "cf-core": "4.7.0",
         "cf-icons": "4.2.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/cfpb/cfpb-chart-builder#readme",
   "dependencies": {
-    "cf-core": "^4.4.1",
+    "cf-core": "^4.7.0",
     "cf-layout": "^4.5.1",
     "cf-typography": "^4.2.1",
     "core-js": "2.5.7",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "homepage": "https://github.com/cfpb/cfpb-chart-builder#readme",
   "dependencies": {
-    "cf-core": "^4.7.0",
+    "cf-core": "^4.10.0",
     "cf-layout": "^4.5.1",
     "cf-typography": "^4.2.1",
     "core-js": "2.5.7",

--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -5,10 +5,16 @@
 
 @chart-blue-primary: @pacific;
 @chart-blue-secondary: @pacific-60;
+@chart-gold-primary: @dark-gold;
+@chart-gold-secondary: @gold-80;
 @chart-green-primary: @green;
 @chart-green-secondary: @green-60;
 @chart-navy-primary: @navy;
 @chart-navy-secondary: @navy-60;
+@chart-neutral-primary: @neutral;
+@chart-neutral-secondary: @neutral-60;
+@chart-purple-primary: @purple;
+@chart-purple-secondary: @purple-60;
 @chart-teal-primary: @teal;
 @chart-teal-secondary: @teal-60;
 
@@ -541,6 +547,33 @@
       }
     }
 
+    &[data-chart-color='gold'] {
+
+      .highcharts-color-1,
+      .highcharts-color-0,
+      .highcharts-navigator-series .highcharts-graph {
+        stroke: @chart-gold-primary;
+      }
+
+      .highcharts-legend-item span:before  {
+        background: @chart-gold-primary;
+      }
+
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-gold-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
+      }
+    }
+
     &[data-chart-color='green'] {
 
       .highcharts-color-1,
@@ -556,6 +589,60 @@
           width: 15px;
           margin-bottom: 3px;
           background: @chart-green-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
+      }
+    }
+
+    &[data-chart-color='neutral'] {
+
+      .highcharts-color-1,
+      .highcharts-color-0,
+      .highcharts-navigator-series .highcharts-graph {
+        stroke: @chart-neutral-primary;
+      }
+
+      .highcharts-legend-item span:before  {
+        background: @chart-neutral-primary;
+      }
+
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-neutral-primary;
+        }
+        .highcharts-color-1 {
+          height: 1px;
+          margin-bottom: 5px;
+        }
+      }
+    }
+
+    &[data-chart-color='purple'] {
+
+      .highcharts-color-1,
+      .highcharts-color-0,
+      .highcharts-navigator-series .highcharts-graph {
+        stroke: @chart-purple-primary;
+      }
+
+      .highcharts-legend-item span:before  {
+        background: @chart-purple-primary;
+      }
+
+      .highcharts-tooltip {
+        .highcharts-color-1, .highcharts-color-0 {
+          display: inline-block;
+          height: 4px;
+          width: 15px;
+          margin-bottom: 3px;
+          background: @chart-purple-primary;
         }
         .highcharts-color-1 {
           height: 1px;

--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -1,8 +1,8 @@
 @import (less) 'highcharts.css';
 @import (less) 'cf-core.less';
 
-// Chart colors
-
+/* Chart colors
+   TODO: Investigate using highcharts API to set chart colors. */
 @chart-blue-primary: @pacific;
 @chart-blue-secondary: @pacific-60;
 @chart-gold-primary: @dark-gold;
@@ -520,6 +520,9 @@
       stroke-dasharray: 3, 3;
     }
 
+    /* TODO: Investigate using highcharts API to set chart colors and
+       remove references to highcharts CSS classes.
+       Aim to remove all &[data-chart-color= selectors. */
     &[data-chart-color='blue'] {
 
       .highcharts-color-1,

--- a/test/index.html
+++ b/test/index.html
@@ -27,6 +27,34 @@
         <div class="content_wrapper">
             <div class="content_main">
                 <h1>Some Sample CFPB Charts</h1>
+                <hr>
+                <div class="cfpb-chart"
+                     data-chart-color="purple"
+                     data-chart-description="This is the chart description."
+                     data-chart-source="consumer-credit-trends/auto-loans/num_data_AUT.csv"
+                     data-chart-title="Number of loans originated"
+                     data-chart-type="line">
+                     Purple chart, which should have its data source replaced with inquiry data in the future.
+                </div>
+                <hr>
+                <div class="cfpb-chart"
+                     data-chart-color="neutral"
+                     data-chart-description="This is the chart description."
+                     data-chart-source="consumer-credit-trends/auto-loans/num_data_AUT.csv"
+                     data-chart-title="Number of loans originated"
+                     data-chart-type="line">
+                     Neutral chart, which should have its data source replaced with inferred denial data in the future.
+                </div>
+                <hr>
+                <div class="cfpb-chart"
+                     data-chart-color="gold"
+                     data-chart-description="This is the chart description."
+                     data-chart-source="consumer-credit-trends/auto-loans/num_data_AUT.csv"
+                     data-chart-title="Number of loans originated"
+                     data-chart-type="line">
+                     Dark gold chart, for demonstration purposes.
+                </div>
+                <hr>
                 <div id="map">
                      Sample geo map.
                 </div>


### PR DESCRIPTION
Add `dark-gold`, `neutral`, and `purple` from Capital Framework as new colors for line charts

In order to add all three colors, we also needed to update our version of `cf-core`.

## Additions

- Add three new color schemes as options for line charts
- Add new charts with this color to the demo page (using placeholder data)

## Changes
- Upgraded `cf-core` dependency to `4.7.0`

## Testing

1. Run `/.setup.sh` which should be successful (with existing webpack warnings).
2. Run `gulp watch` to view the demo page. Three new line charts should be at the top of the page, in the three new colors but using the auto loan origination data.

## Screenshots

![screen shot 2018-08-17 at 4 01 53 pm](https://user-images.githubusercontent.com/1183435/44286405-fb215700-a236-11e8-9290-dc2a4c18e21c.png)

![screen shot 2018-08-17 at 4 02 01 pm](https://user-images.githubusercontent.com/1183435/44286409-ffe60b00-a236-11e8-84f3-9530b4b2fe4a.png)

![screen shot 2018-08-17 at 4 02 13 pm](https://user-images.githubusercontent.com/1183435/44286413-03799200-a237-11e8-9ade-385d4965a6db.png)

## Notes

I didn't see the notification that the contributing guidelines had changed until after I opened this PR, so it's not coming from a fork. Mea culpa.

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [x] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [x] New functions include new tests
* [x] New functions are documented (with a description, list of inputs, and expected output)
* [x] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [x] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
