### PR TITLE
Add custom axis

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,11 @@ For example, `bar` charts currently require a group key (e.g. `Number of Loans`)
 
 Optional. Hardcoded y-axis label for the chart.
 
+**options.axisFormatter**: `Object`
+
+Optional. An Object that contains a `yAxisOptions` method for setting the
+chart's y-axis options.
+
 **options.tooltipFormatter**: `Function`
 
 Optional. Function that returns HTML to format the chart's tooltip.

--- a/src/js/charts/axes/axisDefault.js
+++ b/src/js/charts/axes/axisDefault.js
@@ -1,0 +1,27 @@
+/**
+ * Object of highchart y-axis options.
+ * See https://api.highcharts.com/highcharts/yAxis
+ * @param {string} customLabel - Custom label for the y-axis.
+ * @returns {Object} options object.
+ */
+function yAxisOptions( customLabel ) {
+  const opts = {
+    showLastLabel: true,
+    opposite: false,
+    className: 'axis-label',
+    title: {
+      offset: 0,
+      reserveSpace: false
+    }
+  };
+
+  if ( customLabel ) {
+    opts.title.text = customLabel;
+  }
+
+  return opts;
+}
+
+module.exports = {
+  yAxisOptions
+};

--- a/src/js/charts/axes/axisInquiries.js
+++ b/src/js/charts/axes/axisInquiries.js
@@ -1,0 +1,35 @@
+/* TODO: Use import instead. This is currently stopped by the test suite.
+   See https://[GHE]/CFGOV/platform/issues/2925 */
+const axisDefault = require( './axisDefault' );
+
+/**
+ * Object of highchart y-axis options.
+ * See https://api.highcharts.com/highcharts/yAxis
+ * @param {string} customLabel - Custom label for the y-axis.
+ * @returns {Object} Options object.
+ */
+function yAxisOptions( customLabel ) {
+  const opts = axisDefault.yAxisOptions( customLabel );
+  opts.title.text = _yAxisTitleText( customLabel );
+
+  return opts;
+}
+
+/**
+ * Get the text of the y-axis title.
+ * See https://api.highcharts.com/highcharts/yAxis.title.text
+ *
+ * @param {sting} yAxisLabel - A string to use for the y-axis label.
+ * @returns {string} Appropriate y-axis title.
+ */
+function _yAxisTitleText( yAxisLabel ) {
+  // Return if the label is customized.
+  if ( yAxisLabel ) return yAxisLabel;
+
+  // Set a default.
+  return 'Index (January 2009 = 100)';
+}
+
+module.exports = {
+  yAxisOptions
+};

--- a/src/js/charts/axes/axisOriginations.js
+++ b/src/js/charts/axes/axisOriginations.js
@@ -1,0 +1,70 @@
+/* TODO: Use import instead. This is currently stopped by the test suite.
+   See https://[GHE]/CFGOV/platform/issues/2925 */
+const axisDefault = require( './axisDefault' );
+const getFirstNumber = require( '../../utils/calculation' ).getFirstNumber;
+/**
+ * Object of highchart y-axis options.
+ * See https://api.highcharts.com/highcharts/yAxis
+ * @param {string} customLabel - Custom label for the y-axis.
+ * @param {Object} data - Data for y-axis rows.
+ * @returns {Object} Options object.
+ */
+function yAxisOptions( customLabel, data ) {
+  const opts = axisDefault.yAxisOptions( customLabel );
+  opts.title.text = _yAxisTitleText( customLabel, data );
+  opts.labels = {};
+  opts.labels.formatter = function() {
+    return _yAxisLabelsFormatter( this.value );
+  };
+  return opts;
+}
+
+/**
+ * Get the text of the y-axis title.
+ *
+ * @param  {sting} yAxisLabel  A string to use for the y-axis label.
+ * @param  {array} chartData  An array of values to check.
+ * @returns {string} Appropriate y-axis title.
+ */
+function _yAxisTitleText( yAxisLabel, chartData ) {
+  // Return if the label is customized.
+  if ( yAxisLabel ) return yAxisLabel;
+
+  if ( !chartData ) return 'Values';
+
+  let term = 'Number';
+  let unit = 'millions';
+  const firstChartNumber = getFirstNumber( chartData );
+
+  if ( !firstChartNumber ) {
+    return firstChartNumber;
+  }
+
+  if ( firstChartNumber % 1000000000 < firstChartNumber ) {
+    term = 'Volume';
+    unit = 'billions';
+  }
+
+  return `${ term } of originations (in ${ unit })`;
+}
+
+/**
+ * Convert the data point's unit to M or B.
+ *
+ * @param  {int} value  Data point's value
+ * @returns {int} Data point's value over million or billion.
+ */
+function _yAxisLabelsFormatter( value ) {
+  // If it's 0 or borked data gets passed in, return it.
+  if ( !value ) {
+    return value;
+  }
+  if ( value % 1000000000 < value ) {
+    return `${ value / 1000000000 }B`;
+  }
+  return `${ value / 1000000 }M`;
+}
+
+module.exports = {
+  yAxisOptions
+};

--- a/src/js/charts/axes/index.js
+++ b/src/js/charts/axes/index.js
@@ -1,0 +1,11 @@
+/* TODO: Use import instead. This is currently stopped by the test suite.
+   See https://[GHE]/CFGOV/platform/issues/2925 */
+const axisDefault = require( './axisDefault' );
+const axisOriginations = require( './axisOriginations' );
+const axisInquiries = require( './axisInquiries' );
+
+module.exports = {
+  axisDefault,
+  axisOriginations,
+  axisInquiries
+};

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -100,12 +100,12 @@ function _createCharts() {
   for ( const chart of charts ) {
     const chartOptions = {
       el: chart,
-      title: chart.getAttribute( 'data-chart-title' ),
-      yAxisLabel: chart.getAttribute( 'data-chart-y-axis-label' ),
       type: chart.getAttribute( 'data-chart-type' ),
+      source: chart.getAttribute( 'data-chart-source' ),
+      title: chart.getAttribute( 'data-chart-title' ),
       color: chart.getAttribute( 'data-chart-color' ),
-      metadata: chart.getAttribute( 'data-chart-metadata' ),
-      source: chart.getAttribute( 'data-chart-source' )
+      yAxisLabel: chart.getAttribute( 'data-chart-y-axis-label' ),
+      metadata: chart.getAttribute( 'data-chart-metadata' )
     };
 
     const dataAttrFormatterStr = 'data-chart-axes-formatter';

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,6 +5,7 @@ require( 'core-js/fn/array/index-of' );
 
 const documentReady = require( './utils/document-ready' );
 const createChart = require( './charts' );
+const axes = require( './charts/axes' );
 const ajax = require( './utils/get-data' );
 const shapes = require( './utils/map-shapes' );
 
@@ -97,7 +98,7 @@ function _createCharts() {
   }
 
   for ( const chart of charts ) {
-    new Chart( {
+    const chartOptions = {
       el: chart,
       title: chart.getAttribute( 'data-chart-title' ),
       yAxisLabel: chart.getAttribute( 'data-chart-y-axis-label' ),
@@ -105,7 +106,18 @@ function _createCharts() {
       color: chart.getAttribute( 'data-chart-color' ),
       metadata: chart.getAttribute( 'data-chart-metadata' ),
       source: chart.getAttribute( 'data-chart-source' )
-    } );
+    };
+
+    const dataAttrFormatterStr = 'data-chart-axes-formatter';
+    const axisLabelFormatter = chart.getAttribute( dataAttrFormatterStr );
+
+    if ( typeof axes[axisLabelFormatter] === 'undefined' ) {
+      chartOptions.axisFormatter = axes.axisDefault;
+    } else {
+      chartOptions.axisFormatter = axes[axisLabelFormatter];
+    }
+
+    new Chart( chartOptions );
   }
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -53,6 +53,7 @@
                 <div class="cfpb-chart"
                      data-chart-color="green"
                      data-chart-description="This is the chart description."
+                     data-chart-axes-formatter="axisOriginations"
                      data-chart-source="consumer-credit-trends/auto-loans/num_data_AUT.csv"
                      data-chart-type="line">
                      This is the chart description.
@@ -70,6 +71,7 @@
                 <div class="cfpb-chart"
                      data-chart-color="green"
                      data-chart-description="This is the chart description."
+                     data-chart-axes-formatter="axisOriginations"
                      data-chart-source="consumer-credit-trends/auto-loans/vol_data_AUT.csv"
                      data-chart-type="line">
                      This is the chart description.
@@ -96,6 +98,7 @@
                 <div class="cfpb-chart"
                      data-chart-color="green"
                      data-chart-description="Deep subprime (credit scores below 580)."
+                     data-chart-axes-formatter="axisOriginations"
                      data-chart-metadata="Deep subprime"
                      data-chart-source="consumer-credit-trends/auto-loans/volume_data_Score_Level_AUT.csv"
                      data-chart-type="line">
@@ -105,6 +108,7 @@
                 <div class="cfpb-chart"
                      data-chart-color="teal"
                      data-chart-description="Subprime (credit scores 580 - 619)."
+                     data-chart-axes-formatter="axisOriginations"
                      data-chart-metadata="Subprime"
                      data-chart-source="consumer-credit-trends/auto-loans/volume_data_Score_Level_AUT.csv"
                      data-chart-type="line">
@@ -123,6 +127,7 @@
                 <div class="cfpb-chart"
                      data-chart-color="blue"
                      data-chart-description="High income (relative income 120% or above)."
+                     data-chart-axes-formatter="axisOriginations"
                      data-chart-metadata="High"
                      data-chart-source="consumer-credit-trends/mortgages/volume_data_Income_Level_MTG.csv"
                      data-chart-type="line">
@@ -183,6 +188,7 @@
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inferred denials (auto)."
                      data-chart-y-axis-label="Index (January 2009 = 100)"
+                     data-chart-axes-formatter="axisInquiries"
                      data-chart-source="consumer-credit-trends/auto-loans/den_data_AUT.csv"
                      data-chart-type="line">
                      This is the chart description.

--- a/test/unit_tests/charts/LineChartComparison_test.js
+++ b/test/unit_tests/charts/LineChartComparison_test.js
@@ -27,7 +27,7 @@ mock( 'highcharts/js/modules/accessibility', () => {
   // do nothing
 } );
 
-const LineChart = require( '../../../src/js/charts/LineChartComparison.js' );
+const LineChart = require( '../../../src/js/charts/LineChartComparison' );
 let line;
 
 describe( 'LineChartComparison', () => {

--- a/test/unit_tests/charts/axes/axisDefault_test.js
+++ b/test/unit_tests/charts/axes/axisDefault_test.js
@@ -1,0 +1,20 @@
+/* global before describe it */
+const chai = require( 'chai' );
+const expect = chai.expect;
+const axisDefault = require( '../../../../src/js/charts/axes/axisDefault' );
+
+let UNDEFINED;
+
+describe( 'axisDefault', () => {
+  describe( 'yAxisOptions', () => {
+
+    it( 'should return object without title', () => {
+      expect( axisDefault.yAxisOptions().title.text ).to.equal( UNDEFINED );
+    } );
+
+    it( 'should return object with title when title is passed', () => {
+      expect( axisDefault.yAxisOptions( 'test-title' ).title.text ).to.equal( 'test-title' );
+    } );
+
+  } );
+} );

--- a/test/unit_tests/charts/axes/axisInquiries_test.js
+++ b/test/unit_tests/charts/axes/axisInquiries_test.js
@@ -1,0 +1,18 @@
+/* global before describe it */
+const chai = require( 'chai' );
+const expect = chai.expect;
+const axisInquiries = require( '../../../../src/js/charts/axes/axisInquiries' );
+
+describe( 'axisInquiries', () => {
+  describe( 'yAxisOptions', () => {
+
+    it( 'should return object with default title', () => {
+      expect( axisInquiries.yAxisOptions().title.text ).to.equal( 'Index (January 2009 = 100)' );
+    } );
+
+    it( 'should return object with title when title is passed', () => {
+      expect( axisInquiries.yAxisOptions( 'test-title' ).title.text ).to.equal( 'test-title' );
+    } );
+
+  } );
+} );

--- a/test/unit_tests/charts/axes/axisOriginations_test.js
+++ b/test/unit_tests/charts/axes/axisOriginations_test.js
@@ -11,7 +11,22 @@ describe( 'axisOriginations', () => {
     } );
 
     it( 'should return object with title when title is passed', () => {
-      expect( axisOriginations.yAxisOptions( 'test-title' ).title.text ).to.equal( 'test-title' );
+      expect( axisOriginations.yAxisOptions( 'test-title' ).title.text )
+        .to.equal( 'test-title' );
+    } );
+
+    it( 'should return object with title in millions', () => {
+      const mockData = [ [ 'one', 1 ] ];
+      const opts = axisOriginations.yAxisOptions( null, mockData );
+      expect( opts.title.text )
+        .to.equal( 'Number of originations (in millions)' );
+    } );
+
+    it( 'should return object with title in billions', () => {
+      const mockData = [ [ 'one', 1000000000000 ] ];
+      const opts = axisOriginations.yAxisOptions( null, mockData );
+      expect( opts.title.text )
+        .to.equal( 'Volume of originations (in billions)' );
     } );
 
   } );

--- a/test/unit_tests/charts/axes/axisOriginations_test.js
+++ b/test/unit_tests/charts/axes/axisOriginations_test.js
@@ -1,0 +1,18 @@
+/* global before describe it */
+const chai = require( 'chai' );
+const expect = chai.expect;
+const axisOriginations = require( '../../../../src/js/charts/axes/axisOriginations' );
+
+describe( 'axisOriginations', () => {
+  describe( 'yAxisOptions', () => {
+
+    it( 'should return object with default title', () => {
+      expect( axisOriginations.yAxisOptions().title.text ).to.equal( 'Values' );
+    } );
+
+    it( 'should return object with title when title is passed', () => {
+      expect( axisOriginations.yAxisOptions( 'test-title' ).title.text ).to.equal( 'test-title' );
+    } );
+
+  } );
+} );


### PR DESCRIPTION
Labels contain logic so can't be set 

## Additions

- Adds `data-chart-axes-formatter` attribute to chart markup.

## Changes

- Moves unit tests into `/charts/` directory to match src structure.
- Creates variables in line chart for properties passed in via markup.
- Creates axes directory for providing custom axes formatters.

## Testing

- `gulp test` should pass.
- `gulp build && gulp watch` should look unchanged for existing charts, but have four new charts at the bottom for the inquiries. These demonstrate:
 - No `data-chart-y-axis-label` or `data-chart-axes-formatter` attributes. **Show only default row values**.
 - Only `data-chart-axes-formatter` attribute. **Show label and row values**.
 - Only `data-chart-y-axis-label` attribute. **Show custom label and default row values**.
 - Both `data-chart-y-axis-label` and `data-chart-axes-formatter` attributes. **Show custom label and row values**.

## Screenshot

![screen shot 2018-08-22 at 12 32 18 pm](https://user-images.githubusercontent.com/704760/44477018-7a33d800-a607-11e8-9128-3ce3c611fe4f.png)

## Todo

- Turns out Wagtail needs a UI update for setting the axes formatter for a chart, which should be a drop-down with formatter for the Line chart. The custom y-axis label field in wagtail should probably be deprecated in that case and just be set in the formatter (UNLESS there is a need for lots of different static y-axis labels).