### PR TITLE
Update label to 4 months of projected data for inquiry index charts

### DIFF
--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -77,8 +77,8 @@ function _getTickValue( value ) {
 }
 
 class LineChart {
-  constructor( { el, description, data, metadata, yAxisLabel } ) {
-    data = process.originations( data[0], metadata );
+  constructor( { el, description, data, metadata, source, yAxisLabel } ) {
+    data = process.originations( data[0], metadata, source );
 
     const options = {
       chart: {

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -77,8 +77,8 @@ function _getTickValue( value ) {
 }
 
 class LineChart {
-  constructor( { el, description, data, metadata, source, yAxisLabel } ) {
-    data = process.originations( data[0], metadata, source );
+  constructor( { el, description, data, metadata, yAxisLabel } ) {
+    data = process.originations( data[0], metadata );
 
     const options = {
       chart: {

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -11,8 +11,8 @@ Highcharts.setOptions( {
 } );
 
 class LineChartIndex {
-  constructor( { el, description, data, metadata, yAxisLabel } ) {
-    data = process.originations( data[0], metadata );
+  constructor( { el, description, data, metadata, source, yAxisLabel } ) {
+    data = process.originations( data[0], metadata, source );
     const options = {
       chart: {
         marginRight: 0,

--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -1,6 +1,8 @@
 const getTileMapColor = require( './get-tile-map-color' );
 const getTileMapState = require( './get-tile-map-state' );
 
+let UNDEFINED;
+
 /**
  * Returns an object with the UTC timestamp number in milliseconds
  * and human-friendly month and year for a given date in either format.
@@ -230,7 +232,7 @@ function processYoyData( data, group ) {
  */
 function getProjectedTimestamp( valuesList, projectedRange = 6 ) {
   if ( projectedRange === 0 ) {
-    return null;
+    return UNDEFINED;
   }
 
   const projectedMonth = valuesList[valuesList.length - projectedRange][0];

--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -2,10 +2,15 @@ const getTileMapColor = require( './get-tile-map-color' );
 const getTileMapState = require( './get-tile-map-state' );
 
 /**
- * Returns an object with the UTC timestamp number in milliseconds and human-friendly month and year for a given date in either format
+ * Returns an object with the UTC timestamp number in milliseconds
+ * and human-friendly month and year for a given date in either format.
  *
- * @param {number} index - counter starting at 0 representing the month and year for a data point. 0 is January 2000, 1 is February 2000, etc.
- * @returns {number} UTC timestamp in milliseconds representing the month and year for the given date index.
+ * @param {number} index -
+ *   Counter starting at 0 representing the month and year for a data point.
+ *   0 is January 2000, 1 is February 2000, etc.
+ * @returns {number}
+ *   UTC timestamp in milliseconds representing the month and year
+ *   for the given date index.
  */
 function formatDate( index ) {
   const year = Math.floor( index / 12 ) + 2000;
@@ -17,10 +22,17 @@ function formatDate( index ) {
 }
 
 /**
- * Returns an object with the UTC timestamp number in milliseconds and human-friendly month and year for a given date in either format
+ * Returns an object with the UTC timestamp number in milliseconds
+ * and human-friendly month and year for a given date in either format.
  *
- * @param {number|string} date - UTC timestamp in milliseconds representing the month and year for a given data point, e.g. 1477958400000, OR a string in Month + YYYY format for a given data point, e.g. "January 2000"
- * @returns {Object} object with UTC timestamp in milliseconds and the human-readable version of the month and year for the given date.
+ * @param {number|string} date -
+ *   UTC timestamp in milliseconds representing the month
+ *   and year for a given data point, e.g. 1477958400000,
+ *   OR a string in Month + YYYY format for a given data point,
+ *   e.g. "January 2000".
+ * @returns {Object}
+ *   Object with UTC timestamp in milliseconds and the human-readable version
+ *   of the month and year for the given date.
  */
 function convertDate( date ) {
   let humanFriendly = null;
@@ -61,8 +73,8 @@ function convertDate( date ) {
 /**
  * Prepares mortgage delinquency data for Highcharts.
  *
- * @param {number} datasets - Raw JSON from mortgage-performance API
- * @returns {Object} datasets - Nested array
+ * @param {number} datasets - Raw JSON from mortgage-performance API.
+ * @returns {Object} datasets - Nested array.
  */
 function processDelinquencies( datasets ) {
   if ( typeof datasets !== 'object' ) {
@@ -83,21 +95,19 @@ function processDelinquencies( datasets ) {
 }
 
 /**
- * Returns a data object with data starting in January 2009 for use in all line charts
+ * Returns data starting in January 2009 for use in all line charts.
  *
- * @param {number} data - Response from requested JSON file.
+ * @param {number} data - response from requested JSON file.
  * @param {string} [group] -
- *   Optional parameter for specifying if the chart requires use
- *   of a "group" property in the JSON,
- *   for example, the charts with a group of "Younger than 30"
- *   will filter data to only include values matching that group.
+ *   Optional parameter for specifying if the chart requires use of a "group"
+ *   property in the JSON, for example the charts with a group of "Younger
+ *   than 30" will filter data to only include values matching that group.
  * @param {string} [source] -
- *   Optional parameter for the file url and name.
- *   Used for inquiry index files that have 4 months
- *   of projected data instead of 6.
- * @returns {Object}
- *   data - object with adjusted and unadjusted value arrays containing
- *   timestamps and a number value.
+ *   Optional parameter for the file url and name. Used for inquiry index files
+ *   which have 4 months of projected data instead of 6.
+ * @returns {Object} data -
+ *   Object with adjusted and unadjusted value arrays containing timestamps
+ *   and a number value.
  */
 function processNumOriginationsData( data, group, source ) {
 
@@ -155,11 +165,16 @@ function processNumOriginationsData( data, group, source ) {
 }
 
 /**
- * Returns a data object with data starting in January 2009 for use in all bar charts
+ * Returns data starting in January 2009 for use in all bar charts.
  *
- * @param {number} data - response from requested JSON file
- * @param {string} group - optional parameter for specifying if the chart requires use of a "group" property in the JSON, for example the charts with a group of "Younger than 30" will filter data to only include values matching that group
- * @returns {Object} data - object with adjusted and unadjusted value arrays containing timestamps and a number value
+ * @param {number} data - response from requested JSON file.
+ * @param {string} [group] -
+ *   Optional parameter for specifying if the chart requires use of a "group"
+ *   property in the JSON, for example the charts with a group of "Younger
+ *   than 30" will filter data to only include values matching that group.
+ * @returns {Object} data -
+ *   Object with adjusted and unadjusted value arrays containing timestamps
+ *   and a number value.
  */
 function processYoyData( data, group ) {
 
@@ -194,16 +209,23 @@ function processYoyData( data, group ) {
 }
 
 /**
- * Returns a UTC timestamp number for the month when each graph's data is projected
+ * Returns a UTC timestamp number for the month
+ * when each graph's data is projected.
  *
  * For Mortgage Performance Trends data, there is no projected data.
- * For Consumer Credit Trends data, projected data is for the last 6 months, except for inquiry index data, which is for the last 4 months, and inferred denials data, which is for the last _[@todo: add value once these charts are added]_ months.
+ * For Consumer Credit Trends data, projected data is for the last 6 months,
+ * except for inquiry index data, which is for the last 4 months,
+ * and inferred denials data, which is for the last months.
+ * TODO: add value once these charts are added.
  *
- * @param {Array} valuesList - list of values from the data, containing an array with timestamp representing the month and year at index 0, and the value at index 1. Requires at least six months of data (six array items).
+ * @param {Array} valuesList -
+ *   List of values from the data, containing an array with timestamp
+ *   representing the month and year at index 0, and the value at index 1.
+ *   Requires at least six months of data (six array items).
  * @param {string} projectedRange -
  *   Number of months in the data that is to be labeled projected.
  *   The default is 6 months, inquiry index charts are 4 months, etc.
- * @returns {number} a timestamp.
+ * @returns {number} A timestamp.
  */
 function getProjectedTimestamp( valuesList, projectedRange = 6 ) {
   if ( projectedRange === 0 ) {
@@ -216,10 +238,15 @@ function getProjectedTimestamp( valuesList, projectedRange = 6 ) {
 }
 
 /**
- * Returns a human-readable string representing the month and year after which data in each graph is projected
+ * Returns a human-readable string representing the month and year after,
+ * which data in each graph is projected.
  *
- * @param {number} timestamp - UTC timestamp representing the milliseconds elapsed since the UNIX epoch, for the month when each graph begins displaying projected data
- * @returns {string} projectedDate - text with the Month and Year of the projected data cutoff point, for use in labeling projected date in graphs
+ * @param {number} timestamp -
+ *   UTC timestamp representing the milliseconds elapsed since the UNIX epoch,
+ *   for the month when each graph begins displaying projected data.
+ * @returns {string}
+ *   projectedDate - text with the Month and Year of the projected data cutoff
+ *   point, for use in labeling projected date in graphs.
  */
 function getProjectedDate( timestamp ) {
 

--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -153,7 +153,7 @@ function processNumOriginationsData( data, group, source ) {
   } );
 
   data.projectedDate = {};
-  const fileNameMatch = 'inquiry';
+  const fileNameMatch = 'inq';
   let projectedMonths = 6;
   if ( source && source.includes( fileNameMatch ) ) {
     projectedMonths = 4;
@@ -214,9 +214,8 @@ function processYoyData( data, group ) {
  *
  * For Mortgage Performance Trends data, there is no projected data.
  * For Consumer Credit Trends data, projected data is for the last 6 months,
- * except for inquiry index data, which is for the last 4 months,
- * and inferred denials data, which is for the last months.
- * TODO: add value once these charts are added.
+ * except for inquiry index data, which is for the last 4 months, and inferred 
+ * denials index data, which has no projected data.
  *
  * @param {Array} valuesList -
  *   List of values from the data, containing an array with timestamp
@@ -229,7 +228,7 @@ function processYoyData( data, group ) {
  */
 function getProjectedTimestamp( valuesList, projectedRange = 6 ) {
   if ( projectedRange === 0 ) {
-    return false;
+    return null;
   }
 
   const projectedMonth = valuesList[valuesList.length - projectedRange][0];

--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -153,10 +153,12 @@ function processNumOriginationsData( data, group, source ) {
   } );
 
   data.projectedDate = {};
-  const fileNameMatch = 'inq';
   let projectedMonths = 6;
-  if ( source && source.includes( fileNameMatch ) ) {
+  // set number of months of projected data based on whether source filename includes 'inq' or 'den' for inquiries or denials
+  if ( source && source.includes( 'inq' ) ) {
     projectedMonths = 4;
+  } else if ( source && source.includes( 'den' ) ) {
+    projectedMonths = 0;
   }
   data.projectedDate.timestamp = getProjectedTimestamp( data.adjusted, projectedMonths );
   data.projectedDate.label = getProjectedDate( data.projectedDate.timestamp );
@@ -214,7 +216,7 @@ function processYoyData( data, group ) {
  *
  * For Mortgage Performance Trends data, there is no projected data.
  * For Consumer Credit Trends data, projected data is for the last 6 months,
- * except for inquiry index data, which is for the last 4 months, and inferred 
+ * except for inquiry index data, which is for the last 4 months, and inferred
  * denials index data, which has no projected data.
  *
  * @param {Array} valuesList -

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -200,6 +200,7 @@ describe( 'process-json', () => {
       }
     };
     const test = originations( data, 'test', 'inquiry_test_file.csv' );
+    const differentTest = originations( data, 'test', 'denials_test_file.csv' );
 
     it( 'should eliminate dates before 2009', () => {
       expect( test.adjusted[0][0] ).toBe( 1230768000000 );
@@ -214,6 +215,8 @@ describe( 'process-json', () => {
       expect( test.projectedDate.timestamp ).toBe( 1241136000000 );
       expect( test.projectedDate.label ).toBe( 'April 2009' );
     } );
+
+
 
   } );
 

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -11,6 +11,9 @@ describe( 'process-json', () => {
   const getProjectedTimestamp = processJSON.getProjectedTimestamp;
   const convertDate = processJSON.convertDate;
 
+  let data;
+  let testData;
+
   describe( 'formatDate', () => {
 
     it( 'should convert a month index into the correct UTC timestamp ' +
@@ -87,19 +90,20 @@ describe( 'process-json', () => {
   } );
 
   describe( 'getProjectedTimestamp', () => {
-
-    const dataList = [
-      [ 1477958400000, 1 ], // nov 16
-      [ 1480550400000, 2 ], // dec
-      [ 1483228800000, 3 ], // jan 17
-      [ 1485907200000, 4 ], // feb
-      [ 1488326400000, 5 ], // mar
-      [ 1491004800000, 6 ], // apr
-      [ 1493596800000, 7 ], // may
-      [ 1496275200000, 8 ], // june
-      [ 1498867200000, 9 ], // july
-      [ 1501545600000, 10 ] // aug
-    ];
+    beforeEach( () => {
+      data = [
+        [ 1477958400000, 1 ], // nov 16
+        [ 1480550400000, 2 ], // dec
+        [ 1483228800000, 3 ], // jan 17
+        [ 1485907200000, 4 ], // feb
+        [ 1488326400000, 5 ], // mar
+        [ 1491004800000, 6 ], // apr
+        [ 1493596800000, 7 ], // may
+        [ 1496275200000, 8 ], // june
+        [ 1498867200000, 9 ], // july
+        [ 1501545600000, 10 ] // aug
+      ];
+    } );
 
     it( 'should return UTC timestamp for ' +
         'the first month of the projected data, ' +
@@ -107,184 +111,194 @@ describe( 'process-json', () => {
         'given at least six months of data ' +
         'and no projectedRange argument', () => {
       // Expect to be march.
-      expect( getProjectedTimestamp( dataList ) ).toBe( 1488326400000 );
+      expect( getProjectedTimestamp( data ) ).toBe( 1488326400000 );
     } );
 
     it( 'should return UTC timestamp for ' +
         'the first month of the projected data, ' +
         'for the specified number of months before the given UTC date', () => {
       // march
-      expect( getProjectedTimestamp( dataList, 6 ) ).toBe( 1488326400000 );
+      expect( getProjectedTimestamp( data, 6 ) ).toBe( 1488326400000 );
       // may
-      expect( getProjectedTimestamp( dataList, 4 ) ).toBe( 1493596800000 );
+      expect( getProjectedTimestamp( data, 4 ) ).toBe( 1493596800000 );
       // aug
-      expect( getProjectedTimestamp( dataList, 1 ) ).toBe( 1501545600000 );
+      expect( getProjectedTimestamp( data, 1 ) ).toBe( 1501545600000 );
     } );
 
     it( 'should return null if given a value of 0 months projected', () => {
-      expect( getProjectedTimestamp( dataList, 0 ) ).toBe( null );
+      expect( getProjectedTimestamp( data, 0 ) ).toBe( null );
     } );
 
   } );
 
   describe( 'processYoyData', () => {
-    const data = {
-      test: [
-        [ 1117584000000, 100 ], // jun 2005
-        [ 1230768000000, 0.1 ], // jan 2009
-        [ 1233446400000, -0.2 ], // feb 2009
-        [ 1235865600000, 0.25 ], // march 2009
-        [ 1238544000000, 0 ], // apr 2009
-        [ 1241136000000, -0.1 ], // may 2009
-        [ 1243814400000, 1.44 ], // june 2009
-        [ 1246406400000, 0.92 ], // july 2009
-        [ 1249084800000, 0.01 ], // aug 2009
-        [ 1251763200000, 0.95 ], // sept 2009
-        [ 1254355200000, 0.05 ], // oct 2009
-        [ 1257033600000, 0.93 ], // nov 2009
-        [ 1259625600000, 0.33 ] // dec 2009
-      ]
-    };
-    const test = yoy( data, 'test' );
+    beforeEach( () => {
+      data = {
+        test: [
+          [ 1117584000000, 100 ], // jun 2005
+          [ 1230768000000, 0.1 ], // jan 2009
+          [ 1233446400000, -0.2 ], // feb 2009
+          [ 1235865600000, 0.25 ], // march 2009
+          [ 1238544000000, 0 ], // apr 2009
+          [ 1241136000000, -0.1 ], // may 2009
+          [ 1243814400000, 1.44 ], // june 2009
+          [ 1246406400000, 0.92 ], // july 2009
+          [ 1249084800000, 0.01 ], // aug 2009
+          [ 1251763200000, 0.95 ], // sept 2009
+          [ 1254355200000, 0.05 ], // oct 2009
+          [ 1257033600000, 0.93 ], // nov 2009
+          [ 1259625600000, 0.33 ] // dec 2009
+        ]
+      };
+      testData = yoy( data, 'test' );
+    } );
 
     it( 'should eliminate dates before 2009', () => {
-      expect( test[0][0] ).toBe( 1230768000000 );
+      expect( testData[0][0] ).toBe( 1230768000000 );
     } );
 
     it( 'should identify and select the proper group', () => {
-      expect( test[0][0] ).toBe( 1230768000000 );
+      expect( testData[0][0] ).toBe( 1230768000000 );
     } );
 
     it( 'should convert decimals to percentages', () => {
-      expect( test[0][1] ).toBe( 10 );
-      expect( test[1][1] ).toBe( -20 );
+      expect( testData[0][1] ).toBe( 10 );
+      expect( testData[1][1] ).toBe( -20 );
     } );
 
     it( 'should assign the correct projected dates, 6 months back', () => {
       // July 2009
-      expect( test.projectedDate.timestamp ).toBe( 1246406400000 );
+      expect( testData.projectedDate.timestamp ).toBe( 1246406400000 );
       // July 2009
-      expect( test[test.length - 6][1] ).toBe( 92 );
+      expect( testData[testData.length - 6][1] ).toBe( 92 );
       /* June 2009, the label uses the last month of data that isn't projected.
          For projected data starting with July, the label should say June. */
-      expect( test.projectedDate.label ).toBe( 'June 2009' );
+      expect( testData.projectedDate.label ).toBe( 'June 2009' );
     } );
 
   } );
 
   describe( 'processNumOriginationsData', () => {
-    const data = {
-      test: {
-        adjusted: [
-          [ 1117584000000, 1 ],
-          [ 1230768000000, 1239123 ],
-          [ 1233446400000, 888888 ],
-          [ 1235865600000, 1231125 ],
-          [ 1238544000000, 82364821 ],
-          [ 1241136000000, 7654321 ],
-          [ 1243814400000, 1234567 ],
-          [ 1246406400000, 1212123 ],
-          [ 1249084800000, 3434343 ]
-        ],
-        unadjusted: [
-          [ 1117584000000, 1 ],
-          [ 1230768000000, 1239123 ],
-          [ 1233446400000, 888888 ],
-          [ 1235865600000, 1231125 ],
-          [ 1238544000000, 82364821 ],
-          [ 1241136000000, 7654321 ],
-          [ 1243814400000, 1234567 ],
-          [ 1246406400000, 1212123 ],
-          [ 1249084800000, 3434343 ]
-        ]
-      }
-    };
-    const test = originations( data, 'test', 'inquiry_test_file.csv' );
-    const differentTest = originations( data, 'test', 'denials_test_file.csv' );
+    beforeEach( () => {
+      data = {
+        test: {
+          adjusted: [
+            [ 1117584000000, 1 ],
+            [ 1230768000000, 1239123 ],
+            [ 1233446400000, 888888 ],
+            [ 1235865600000, 1231125 ],
+            [ 1238544000000, 82364821 ],
+            [ 1241136000000, 7654321 ],
+            [ 1243814400000, 1234567 ],
+            [ 1246406400000, 1212123 ],
+            [ 1249084800000, 3434343 ]
+          ],
+          unadjusted: [
+            [ 1117584000000, 1 ],
+            [ 1230768000000, 1239123 ],
+            [ 1233446400000, 888888 ],
+            [ 1235865600000, 1231125 ],
+            [ 1238544000000, 82364821 ],
+            [ 1241136000000, 7654321 ],
+            [ 1243814400000, 1234567 ],
+            [ 1246406400000, 1212123 ],
+            [ 1249084800000, 3434343 ]
+          ]
+        }
+      };
+      testData = originations( data, 'test', 'inquiry_test_file.csv' );
+    } );
 
     it( 'should eliminate dates before 2009', () => {
-      expect( test.adjusted[0][0] ).toBe( 1230768000000 );
+      expect( testData.adjusted[0][0] ).toBe( 1230768000000 );
     } );
 
     it( 'should identify and select the proper group', () => {
-      expect( test.adjusted[0][0] ).toBe( 1230768000000 );
+      expect( testData.adjusted[0][0] ).toBe( 1230768000000 );
     } );
 
     it( 'should assign the correct projected dates, ' +
         '4 months for inquiry index charts', () => {
-      expect( test.projectedDate.timestamp ).toBe( 1241136000000 );
-      expect( test.projectedDate.label ).toBe( 'April 2009' );
+      expect( testData.projectedDate.timestamp ).toBe( 1241136000000 );
+      expect( testData.projectedDate.label ).toBe( 'April 2009' );
     } );
 
-
-
+    it( 'should assign the correct projected dates, ' +
+        '0 months for inquiry index charts', () => {
+      const testDataDen = originations( data, 'test', 'denials_test_file.csv' );
+      expect( testDataDen.projectedDate.timestamp ).toBeNull();
+      expect( testDataDen.projectedDate.label ).toBeNull();
+    } );
   } );
 
   describe( 'processMapData', () => {
-    const data = [
-      {
-        name: 'AL',
-        value: '142.84'
-      },
-      {
-        name: 'AK',
-        value: '91.98'
-      },
-      {
-        name: 'AZ',
-        value: '73.14'
-      },
-      {
-        name: 'AR',
-        value: '70.41'
-      }
-    ];
-    const test = map( data );
-
+    beforeEach( () => {
+      data = [
+        {
+          name: 'AL',
+          value: '142.84'
+        },
+        {
+          name: 'AK',
+          value: '91.98'
+        },
+        {
+          name: 'AZ',
+          value: '73.14'
+        },
+        {
+          name: 'AR',
+          value: '70.41'
+        }
+      ];
+      testData = map( data );
+    } );
 
     it( 'should get the correct path for a state', () => {
-      expect( test[0].name ).toBe( 'AL' );
-      expect( test[0].path ).toBe( 'M550,-337L633,-337,633,-253,550,-253,550,-337' );
+      expect( testData[0].name ).toBe( 'AL' );
+      expect( testData[0].path )
+        .toBe( 'M550,-337L633,-337,633,-253,550,-253,550,-337' );
     } );
 
     it( 'should round values', () => {
-      expect( test[0].name ).toBe( 'AL' );
-      expect( test[0].value ).toBe( 143 );
-      expect( test[1].name ).toBe( 'AK' );
-      expect( test[1].value ).toBe( 92 );
-      expect( test[2].name ).toBe( 'AZ' );
-      expect( test[2].value ).toBe( 73 );
+      expect( testData[0].name ).toBe( 'AL' );
+      expect( testData[0].value ).toBe( 143 );
+      expect( testData[1].name ).toBe( 'AK' );
+      expect( testData[1].value ).toBe( 92 );
+      expect( testData[2].name ).toBe( 'AZ' );
+      expect( testData[2].value ).toBe( 73 );
     } );
 
     it( 'should add the correct tooltip', () => {
-      expect( test[0].name ).toBe( 'AL' );
-      expect( test[0].tooltip ).toBe( 'AL increased by 143%' );
+      expect( testData[0].name ).toBe( 'AL' );
+      expect( testData[0].tooltip ).toBe( 'AL increased by 143%' );
     } );
 
   } );
 
   describe( 'processDelinquencies', () => {
-
-    const data = [
-      {
-        meta: {
-          name: 'New York, NY'
+    beforeEach( () => {
+      data = [
+        {
+          meta: {
+            name: 'New York, NY'
+          },
+          data: [ {
+            date: 1199163600000,
+            value: 0.129563846384
+          } ]
         },
-        data: [ {
-          date: 1199163600000,
-          value: 0.129563846384
-        } ]
-      },
-      {
-        meta: {
-          name: 'Miami, FL'
-        },
-        data: [ {
-          date: 1199163600000,
-          value: 0.546287382733
-        } ]
-      }
-    ];
+        {
+          meta: {
+            name: 'Miami, FL'
+          },
+          data: [ {
+            date: 1199163600000,
+            value: 0.546287382733
+          } ]
+        }
+      ];
+    } );
 
     it( 'assign a label', () => {
       const test = delinquencies( data );

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -125,8 +125,8 @@ describe( 'process-json', () => {
       expect( getProjectedTimestamp( data, 1 ) ).toBe( 1501545600000 );
     } );
 
-    it( 'should return null if given a value of 0 months projected', () => {
-      expect( getProjectedTimestamp( data, 0 ) ).toBe( null );
+    it( 'should return undefined if given a value of 0 months projected', () => {
+      expect( getProjectedTimestamp( data, 0 ) ).toBeUndefined();
     } );
 
   } );
@@ -226,7 +226,7 @@ describe( 'process-json', () => {
     it( 'should assign the correct projected dates, ' +
         '0 months for inquiry index charts', () => {
       const testDataDen = originations( data, 'test', 'denials_test_file.csv' );
-      expect( testDataDen.projectedDate.timestamp ).toBeNull();
+      expect( testDataDen.projectedDate.timestamp ).toBeUndefined();
       expect( testDataDen.projectedDate.label ).toBeNull();
     } );
   } );

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -121,8 +121,8 @@ describe( 'process-json', () => {
       expect( getProjectedTimestamp( dataList, 1 ) ).toBe( 1501545600000 );
     } );
 
-    it( 'should return false if given a value of 0 months projected', () => {
-      expect( getProjectedTimestamp( dataList, 0 ) ).toBe( false );
+    it( 'should return null if given a value of 0 months projected', () => {
+      expect( getProjectedTimestamp( dataList, 0 ) ).toBe( null );
     } );
 
   } );

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -224,10 +224,17 @@ describe( 'process-json', () => {
     } );
 
     it( 'should assign the correct projected dates, ' +
-        '0 months for inquiry index charts', () => {
+        '0 months for inferred denial charts', () => {
       const testDataDen = originations( data, 'test', 'denials_test_file.csv' );
       expect( testDataDen.projectedDate.timestamp ).toBeUndefined();
       expect( testDataDen.projectedDate.label ).toBeNull();
+    } );
+
+    it( 'should assign the correct projected dates, ' +
+        '6 months for all other charts', () => {
+      const testDataOther = originations( data, 'test', 'other.csv' );
+      expect( testDataOther.projectedDate.timestamp ).toBe( 1235865600000 );
+      expect( testDataOther.projectedDate.label ).toBe( 'February 2009' );
     } );
   } );
 

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -13,11 +13,13 @@ describe( 'process-json', () => {
 
   describe( 'formatDate', () => {
 
-    it( 'should convert a month index into the correct UTC timestamp in milliseconds representing January 1 2000', function() {
+    it( 'should convert a month index into the correct UTC timestamp ' +
+        'in milliseconds representing January 1 2000', () => {
       expect( formatDate( 0 ) ).toBe( 946684800000 );
     } );
 
-    it( 'should convert a month index into the correct UTC timestamp in milliseconds representing November 1st 2016', function() {
+    it( 'should convert a month index into the correct UTC timestamp ' +
+        'in milliseconds representing November 1st 2016', () => {
       expect( formatDate( 202 ) ).toBe( 1477958400000 );
     } );
 
@@ -27,7 +29,8 @@ describe( 'process-json', () => {
 
     /* 1485925200000 = February 2017
        1477958400000 = Nov 2016 */
-    it( 'should convert a UTC timestamp in milliseconds to a human friendly month and year date', function() {
+    it( 'should convert a UTC timestamp in milliseconds to a ' +
+        'human friendly month and year date', () => {
       expect( convertDate( 946684800000 ).humanFriendly )
         .toBe( 'January 2000' );
       expect( convertDate( 1477958400000 ).humanFriendly )
@@ -37,23 +40,27 @@ describe( 'process-json', () => {
 
     } );
 
-    it( 'should convert a UTC timestamp in milliseconds to a UTC timestamp in milliseconds', function() {
+    it( 'should convert a UTC timestamp in milliseconds ' +
+        'to a UTC timestamp in milliseconds', () => {
       expect( convertDate( 1477958400000 ).timestamp ).toBe( 1477958400000 );
     } );
 
-    it( 'should convert a human friendly month and year date to a UTC timestamp in milliseconds', function() {
+    it( 'should convert a human friendly month and year date ' +
+        'to a UTC timestamp in milliseconds', () => {
       expect( convertDate( 'January 2000' ).timestamp ).toBe( 946684800000 );
       expect( convertDate( 'November 2016' ).timestamp ).toBe( 1477958400000 );
       expect( convertDate( 'February 2017' ).timestamp ).toBe( 1485907200000 );
     } );
 
-    it( 'should convert a human friendly date to a timestamp and back to a human friendly date', function() {
+    it( 'should convert a human friendly date to a timestamp ' +
+        'and back to a human friendly date', () => {
       const february = convertDate( 'February 2017' ).timestamp;
       expect( convertDate( february ).humanFriendly ).toBe( 'February 2017' );
     } );
 
 
-    it( 'should convert a human friendly month and year date to a human friendly month and year date', function() {
+    it( 'should convert a human friendly month ' +
+        'and year date to a human friendly month and year date', () => {
       expect( convertDate( 'February 2017' ).humanFriendly )
         .toBe( 'February 2017' );
     } );
@@ -62,15 +69,18 @@ describe( 'process-json', () => {
 
   describe( 'getProjectedDate', () => {
 
-    it( 'should return a human readable month and year string one month before the given timestamp', function() {
+    it( 'should return a human readable month ' +
+        'and year string one month before the given timestamp', () => {
       expect( getProjectedDate( 1483228800000 ) ).toBe( 'December 2016' );
     } );
 
-    it( 'should return a human readable month and year string one month before the given timestamp', function() {
+    it( 'should return a human readable month ' +
+        'and year string one month before the given timestamp', () => {
       expect( getProjectedDate( 1477958400000 ) ).toBe( 'October 2016' );
     } );
 
-    it( 'should return a human readable month and year string one month before the given timestamp', function() {
+    it( 'should return a human readable month ' +
+        'and year string one month before the given timestamp', () => {
       expect( getProjectedDate( 1485925200000 ) ).toBe( 'January 2017' );
     } );
 
@@ -78,23 +88,41 @@ describe( 'process-json', () => {
 
   describe( 'getProjectedTimestamp', () => {
 
-    it( 'should return UTC timestamp for the first month of the projected data, six months before given UTC date, given at least six months of data', function() {
+    const dataList = [
+      [ 1477958400000, 1 ], // nov 16
+      [ 1480550400000, 2 ], // dec
+      [ 1483228800000, 3 ], // jan 17
+      [ 1485907200000, 4 ], // feb
+      [ 1488326400000, 5 ], // mar
+      [ 1491004800000, 6 ], // apr
+      [ 1493596800000, 7 ], // may
+      [ 1496275200000, 8 ], // june
+      [ 1498867200000, 9 ], // july
+      [ 1501545600000, 10 ] // aug
+    ];
 
-      const dataList = [
-        [ 1477958400000, 1 ], // nov 16
-        [ 1480550400000, 2 ], // dec
-        [ 1483228800000, 3 ], // jan 17
-        [ 1485907200000, 4 ], // feb
-        [ 1488326400000, 5 ], // mar
-        [ 1491004800000, 6 ], // apr
-        [ 1493596800000, 7 ], // may
-        [ 1496275200000, 8 ], // june
-        [ 1498867200000, 9 ], // july
-        [ 1501545600000, 10 ] // aug
-      ];
-
+    it( 'should return UTC timestamp for ' +
+        'the first month of the projected data, ' +
+        'six months before given UTC date, ' +
+        'given at least six months of data ' +
+        'and no projectedRange argument', () => {
       // Expect to be march.
       expect( getProjectedTimestamp( dataList ) ).toBe( 1488326400000 );
+    } );
+
+    it( 'should return UTC timestamp for ' +
+        'the first month of the projected data, ' +
+        'for the specified number of months before the given UTC date', () => {
+      // march
+      expect( getProjectedTimestamp( dataList, 6 ) ).toBe( 1488326400000 );
+      // may
+      expect( getProjectedTimestamp( dataList, 4 ) ).toBe( 1493596800000 );
+      // aug
+      expect( getProjectedTimestamp( dataList, 1 ) ).toBe( 1501545600000 );
+    } );
+
+    it( 'should return false if given a value of 0 months projected', () => {
+      expect( getProjectedTimestamp( dataList, 0 ) ).toBe( false );
     } );
 
   } );
@@ -132,10 +160,14 @@ describe( 'process-json', () => {
       expect( test[1][1] ).toBe( -20 );
     } );
 
-    it( 'should assign the correct projected Dates', () => {
-      expect( test.projectedDate.timestamp ).toBe( 1246406400000 ); // July 2009
-      expect( test[test.length - 6][1] ).toBe( 92 ); // July 2009
-      expect( test.projectedDate.label ).toBe( 'June 2009' ); // June 2009, the label uses the last month of data that isn't projected. For projected data starting with July, the label should say June.
+    it( 'should assign the correct projected dates, 6 months back', () => {
+      // July 2009
+      expect( test.projectedDate.timestamp ).toBe( 1246406400000 );
+      // July 2009
+      expect( test[test.length - 6][1] ).toBe( 92 );
+      /* June 2009, the label uses the last month of data that isn't projected.
+         For projected data starting with July, the label should say June. */
+      expect( test.projectedDate.label ).toBe( 'June 2009' );
     } );
 
   } );
@@ -167,7 +199,7 @@ describe( 'process-json', () => {
         ]
       }
     };
-    const test = originations( data, 'test' );
+    const test = originations( data, 'test', 'inquiry_test_file.csv' );
 
     it( 'should eliminate dates before 2009', () => {
       expect( test.adjusted[0][0] ).toBe( 1230768000000 );
@@ -177,9 +209,10 @@ describe( 'process-json', () => {
       expect( test.adjusted[0][0] ).toBe( 1230768000000 );
     } );
 
-    it( 'should assign the correct projected Dates', () => {
-      expect( test.projectedDate.timestamp ).toBe( 1235865600000 );
-      expect( test.projectedDate.label ).toBe( 'February 2009' );
+    it( 'should assign the correct projected dates, ' +
+        '4 months for inquiry index charts', () => {
+      expect( test.projectedDate.timestamp ).toBe( 1241136000000 );
+      expect( test.projectedDate.label ).toBe( 'April 2009' );
     } );
 
   } );


### PR DESCRIPTION
Updates the projected data function to calculate the projected date cutoff point with a given number of months (previously it was always set to the last 6 months of data). The default is 6 months (most CCT charts) and inquiry index charts show 4 months of projected data. See https://GHE/CFGOV/platform/issues/2945 for details

## Additions

- new parameter `projectedRange` for `getProjectedTimestamp` function. This is the number of months that should be labeled as projected data on a chart. The default is set to 6 months.
- for bar charts data in `processYoyData()`, `getProjectedTimestamp` is called with 6 months as the `projectedRange`
- for line charts data in `processNumOriginationsData()`, `getProjectedTimestamp` is called with 6 months as the `projectedRange` except for charts that have the word `inquiry` in the data source filepath. these are called with the range set to 4 months.

## Testing

- `./setup.sh`
- `gulp test` should pass
- `gulp watch` and go to http://localhost:5000/
- scroll down to the bottom to view the last 3 charts. these demo inquiry index charts should show "Values after August 2017 are projected" and hovering on the projected line with your mouse cursor should September 2017 as the first month of projected data

## Screenshots
Yes, the y axis labels are broken, that is addressed in #129 

![screen shot 2018-08-24 at 6 40 36 pm](https://user-images.githubusercontent.com/702526/44611061-43a7ba00-a7cd-11e8-8f06-4696eda7f921.png)


## Notes

- i had trouble testing the new `source` param with different values in the same `describe()` statement for `processNumOriginationsData()`. for now the test only checks that the value is correctly calculated as 4 months when the `source` string has the word `inquiry` in it. ideally it would also check the date is correct when called with no source value (should default to 6 months).

## Todos

- 

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
