### PR TITLE
Add new LineChartIndex chart

### DIFF
--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -138,7 +138,8 @@
   }
 
   &[data-chart-type='line'],
-  &[data-chart-type='line-comparison'] {
+  &[data-chart-type='line-comparison'],
+  &[data-chart-type='line-index'] {
     .highcharts-plot-line-label {
       margin-left: 15px !important;
       left: 50% !important;
@@ -449,7 +450,8 @@
 
   // Axes
   &[data-chart-type='line'],
-  &[data-chart-type='line-comparison'] {
+  &[data-chart-type='line-comparison'],
+  &[data-chart-type='line-index'] {
 
     .highcharts-yaxis .highcharts-axis-title {
 
@@ -484,7 +486,8 @@
   // Colors and widths
 
   &[data-chart-type='line'],
-  &[data-chart-type='line-comparison'] {
+  &[data-chart-type='line-comparison'],
+  &[data-chart-type='line-index'] {
 
     .highcharts-tracker,
     .highcharts-graph {
@@ -655,7 +658,6 @@
     }
 
     &[data-chart-color='teal'] {
-
 
       .highcharts-color-1,
       .highcharts-color-0,

--- a/src/js/charts/LineChartComparison.js
+++ b/src/js/charts/LineChartComparison.js
@@ -13,8 +13,8 @@ Highcharts.setOptions( {
 /**
  * _getYAxisUnits - Get the text of the y-axis title
  *
- * @param  {array} array  An array of values to check
- * @returns {string}    Appropriate y-axis title
+ * @param {Array} array - An array of values to check
+ * @returns {string} Appropriate y-axis title
  */
 function _getYAxisUnits( array ) {
   const value = getFirstNumber( array );
@@ -44,8 +44,8 @@ function _getYAxisLabel( array ) {
 /**
  * _getTickValue - Convert the data point's unit to M or B.
  *
- * @param  {int} value  Data point's value
- * @returns {int}        Data point's value over million or billion.
+ * @param {number} value - Data point's value
+ * @returns {number} Data point's value over million or billion.
  */
 function _getTickValue( value ) {
   // If borked data gets passed in, return it.

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -158,7 +158,7 @@ class LineChartIndex {
       }
     };
 
-    return this.chart = Highcharts.stockChart( el, options, function( chart ) {
+    this.chart = Highcharts.stockChart( el, options, function( chart ) {
       // label(str, x, y, shape, anchorX, anchorY, useHTML, baseline, className)
       chart.renderer.label(
         'Select time range',
@@ -172,6 +172,8 @@ class LineChartIndex {
         'range-selector-label'
       ).add();
     } );
+
+    return this.chart;
   }
 }
 

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -10,83 +10,16 @@ Highcharts.setOptions( {
   }
 } );
 
-/**
- * _getYAxisUnits - Get the text of the y-axis title
- *
- * @param {Array} array - An array of values to check.
- * @returns {string} Appropriate y-axis title.
- */
-function _getYAxisUnits( array ) {
-  const value = getFirstNumber( array );
-  if ( !value ) {
-    return value;
-  }
-  if ( value % 1000000000 < value ) {
-    return 'billions';
-  }
-  return 'millions';
-}
-
-/**
- * _getYAxisLabel - Get the text of the y-axis title.
- *
- * @param {Array} chartData - An array of values to check.
- * @param {sting} yAxisLabel - A string to use for the y-axis label.
- * @returns {string} Appropriate y-axis title.
- */
-function _getYAxisLabel( chartData, yAxisLabel ) {
-  if ( yAxisLabel ) {
-    return yAxisLabel;
-  }
-
-  let term = 'Number';
-  let unit = 'millions';
-  const firstChartNumber = getFirstNumber( chartData );
-
-  if ( !firstChartNumber ) {
-    return firstChartNumber;
-  }
-
-  if ( firstChartNumber % 1000000000 < firstChartNumber ) {
-    term = 'Volume';
-    unit = 'billions';
-  }
-
-  return term + ' of originations (in ' + unit + ')';
-}
-
-/**
- * _getTickValue - Convert the data point's unit to M or B.
- *
- * @param {number} value - Data point's value
- * @returns {number} Data point's value over million or billion.
- */
-function _getTickValue( value ) {
-  // If it's 0 or borked data gets passed in, return it.
-  if ( !value ) {
-    return value;
-  }
-
-  if ( value % 1000000000 < value ) {
-    return value / 1000000000 + 'B';
-  } else if ( value % 1000000 < value ) {
-    return value / 1000000 + 'M';
-  }
-
-  return value;
-}
-
-class LineChart {
+class LineChartIndex {
   constructor( { el, description, data, metadata, yAxisLabel } ) {
     data = process.originations( data[0], metadata );
-
     const options = {
       chart: {
         marginRight: 0,
         marginTop: 100,
         zoomType: 'none'
       },
-      className: 'cfpb-chart_line',
+      className: 'cfpb-chart_line-index',
       description: description,
       credits: false,
       rangeSelector: {
@@ -163,29 +96,25 @@ class LineChart {
         } ]
       },
       yAxis: {
+        allowDecimals: false,
         showLastLabel: true,
         opposite: false,
         className: 'axis-label',
         title: {
-          text: _getYAxisLabel( data.adjusted, yAxisLabel ),
+          text: 'Index (January 2009 = 100)',
           offset: 0,
           reserveSpace: false
-        },
-        labels: {
-          formatter: function() {
-            return _getTickValue( this.value );
-          }
         }
       },
       tooltip: {
         useHTML: true,
         formatter: function() {
           let tooltip = Highcharts.dateFormat( '%B %Y', this.x );
-          for ( let i = 0; i < this.points.length; i++ ) {
+          for ( let i = 0, len = this.points.length; i < len; i++ ) {
             const point = this.points[i];
             tooltip += "<br><span class='highcharts-color-" +
                        point.series.colorIndex + "'></span> " +
-                       point.series.name + ': ' + Highcharts.numberFormat( point.y, 0 );
+                       point.series.name + ': ' + Highcharts.numberFormat( point.y, 1 );
           }
           return tooltip;
         }
@@ -195,9 +124,6 @@ class LineChart {
           name: 'Seasonally adjusted',
           data: data.adjusted,
           legendIndex: 1,
-          tooltip: {
-            valueDecimals: 0
-          },
           zoneAxis: 'x',
           zones: [ {
             value: data.projectedDate.timestamp
@@ -207,9 +133,6 @@ class LineChart {
           name: 'Unadjusted',
           data: data.unadjusted,
           legendIndex: 2,
-          tooltip: {
-            valueDecimals: 0
-          },
           zoneAxis: 'x',
           zones: [ {
             value: data.projectedDate.timestamp
@@ -235,7 +158,7 @@ class LineChart {
       }
     };
 
-    return Highcharts.stockChart( el, options, function( chart ) {
+    return this.chart = Highcharts.stockChart( el, options, function( chart ) {
       // label(str, x, y, shape, anchorX, anchorY, useHTML, baseline, className)
       chart.renderer.label(
         'Select time range',
@@ -252,4 +175,4 @@ class LineChart {
   }
 }
 
-module.exports = LineChart;
+module.exports = LineChartIndex;

--- a/src/js/charts/index.js
+++ b/src/js/charts/index.js
@@ -1,8 +1,9 @@
 const charts = {};
 charts.bar = require( './BarChart' );
 charts.GeoMap = require( './GeoMap' );
-charts.line = require( './LineChart' );
-charts.LineComparison = require( './LineChartComparison' );
+charts.LineChart = require( './LineChart' );
+charts.LineChartComparison = require( './LineChartComparison' );
+charts.LineChartIndex = require( './LineChartIndex' );
 charts.tileMap = require( './TileMap' );
 
 module.exports = charts;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -27,10 +27,13 @@ class Chart {
         } );
         break;
       case 'line-comparison':
-        this.highchart = new createChart.LineComparison( chartOptions );
+        this.highchart = new createChart.LineChartComparison( chartOptions );
+        break;
+      case 'line-index':
+        this.highchart = new createChart.LineChartIndex( chartOptions );
         break;
       case 'line':
-        this.highchart = createChart.line( chartOptions );
+        this.highchart = new createChart.LineChart( chartOptions );
         break;
       case 'bar':
         this.highchart = createChart.bar( chartOptions );

--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -4,8 +4,8 @@ const getTileMapState = require( './get-tile-map-state' );
 /**
  * Returns an object with the UTC timestamp number in milliseconds and human-friendly month and year for a given date in either format
  *
- * @param {Number} index - counter starting at 0 representing the month and year for a data point. 0 is January 2000, 1 is February 2000, etc.
- * @returns {Number} UTC timestamp in milliseconds representing the month and year for the given date index.
+ * @param {number} index - counter starting at 0 representing the month and year for a data point. 0 is January 2000, 1 is February 2000, etc.
+ * @returns {number} UTC timestamp in milliseconds representing the month and year for the given date index.
  */
 function formatDate( index ) {
   const year = Math.floor( index / 12 ) + 2000;
@@ -19,8 +19,8 @@ function formatDate( index ) {
 /**
  * Returns an object with the UTC timestamp number in milliseconds and human-friendly month and year for a given date in either format
  *
- * @param {(number|string)} date - UTC timestamp in milliseconds representing the month and year for a given data point, e.g. 1477958400000, OR a string in Month + YYYY format for a given data point, e.g. "January 2000"
- * @returns {Obj} object with UTC timestamp in milliseconds and the human-readable version of the month and year for the given date.
+ * @param {number|string} date - UTC timestamp in milliseconds representing the month and year for a given data point, e.g. 1477958400000, OR a string in Month + YYYY format for a given data point, e.g. "January 2000"
+ * @returns {Object} object with UTC timestamp in milliseconds and the human-readable version of the month and year for the given date.
  */
 function convertDate( date ) {
   let humanFriendly = null;
@@ -61,8 +61,8 @@ function convertDate( date ) {
 /**
  * Prepares mortgage delinquency data for Highcharts.
  *
- * @param {Number} datasets - Raw JSON from mortgage-performance API
- * @returns {Obj} datasets - Nested array
+ * @param {number} datasets - Raw JSON from mortgage-performance API
+ * @returns {Object} datasets - Nested array
  */
 function processDelinquencies( datasets ) {
   if ( typeof datasets !== 'object' ) {
@@ -85,9 +85,9 @@ function processDelinquencies( datasets ) {
 /**
  * Returns a data object with data starting in January 2009 for use in all line charts
  *
- * @param {Number} data - response from requested JSON file
- * @param {String} group - optional parameter for specifying if the chart requires use of a "group" property in the JSON, for example the charts with a group of "Younger than 30" will filter data to only include values matching that group
- * @returns {Obj} data - object with adjusted and unadjusted value arrays containing timestamps and a number value
+ * @param {number} data - response from requested JSON file
+ * @param {string} group - optional parameter for specifying if the chart requires use of a "group" property in the JSON, for example the charts with a group of "Younger than 30" will filter data to only include values matching that group
+ * @returns {Object} data - object with adjusted and unadjusted value arrays containing timestamps and a number value
  */
 function processNumOriginationsData( data, group ) {
 
@@ -142,9 +142,9 @@ function processNumOriginationsData( data, group ) {
 /**
  * Returns a data object with data starting in January 2009 for use in all bar charts
  *
- * @param {Number} data - response from requested JSON file
- * @param {String} group - optional parameter for specifying if the chart requires use of a "group" property in the JSON, for example the charts with a group of "Younger than 30" will filter data to only include values matching that group
- * @returns {Obj} data - object with adjusted and unadjusted value arrays containing timestamps and a number value
+ * @param {number} data - response from requested JSON file
+ * @param {string} group - optional parameter for specifying if the chart requires use of a "group" property in the JSON, for example the charts with a group of "Younger than 30" will filter data to only include values matching that group
+ * @returns {Object} data - object with adjusted and unadjusted value arrays containing timestamps and a number value
  */
 function processYoyData( data, group ) {
 
@@ -182,7 +182,7 @@ function processYoyData( data, group ) {
  * Returns a UTC timestamp number for the month when each graph's data is projected
  *
  * @param {Array} valuesList - list of values from the data, containing an array with timestamp representing the month and year at index 0, and the value at index 1. Requires at least six months of data (six array items).
- * @returns {Number} a timestamp.
+ * @returns {number} a timestamp.
  */
 function getProjectedTimestamp( valuesList ) {
   // Projected data begins six months from the latest month of data available
@@ -194,8 +194,8 @@ function getProjectedTimestamp( valuesList ) {
 /**
  * Returns a human-readable string representing the month and year after which data in each graph is projected
  *
- * @param {Number} timestamp - UTC timestamp representing the milliseconds elapsed since the UNIX epoch, for the month when each graph begins displaying projected data
- * @returns {String} projectedDate - text with the Month and Year of the projected data cutoff point, for use in labeling projected date in graphs
+ * @param {number} timestamp - UTC timestamp representing the milliseconds elapsed since the UNIX epoch, for the month when each graph begins displaying projected data
+ * @returns {string} projectedDate - text with the Month and Year of the projected data cutoff point, for use in labeling projected date in graphs
  */
 function getProjectedDate( timestamp ) {
 
@@ -207,7 +207,7 @@ function getProjectedDate( timestamp ) {
 }
 
 /**
- * @param  {Object} data - Data to process.
+ * @param {Object} data - Data to process.
  * @returns {Object} The processed data.
  */
 function processMapData( data ) {

--- a/test/index.html
+++ b/test/index.html
@@ -152,9 +152,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inquiries (auto)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/auto-loans/inq_data_AUT.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
                 <hr>
@@ -162,9 +161,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inquiries (credit cards)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/credit-cards/inq_data_CRC.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
                 <hr>
@@ -172,9 +170,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inquiries (mortgages)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/mortgages/inq_data_MTG.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
                 <hr>
@@ -182,9 +179,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inferred denials (auto)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/auto-loans/den_data_AUT.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
                 <hr>
@@ -192,9 +188,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inferred denials (credit card)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/credit-cards/den_data_CRC.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
                 <hr>
@@ -202,9 +197,8 @@
                 <div class="cfpb-chart"
                      data-chart-color="purple"
                      data-chart-description="Indexed number of people with inferred denials (mortgages)."
-                     data-chart-y-axis-label="Index (January 2009 = 100)"
                      data-chart-source="consumer-credit-trends/mortgages/den_data_MTG.csv"
-                     data-chart-type="line">
+                     data-chart-type="line-index">
                      This is the chart description.
                 </div>
             </div><!-- END .content_main -->


### PR DESCRIPTION
## Additions

- Add new LineChartIndex chart.

## Changes

- Fix erroneous jsdocs.
- Converts line chart to use class (https://github.com/cfpb/cfpb-chart-builder/issues/71)

## Testing

- `gulp build && gulp watch` and check bottom six charts.

## Screenshots

![download](https://user-images.githubusercontent.com/704760/45120476-39ba7b00-b12c-11e8-8db2-c128d3eca56b.png)

