### PR TITLE
Adjust bolding of labels

### DIFF
--- a/src/css/cfpb-chart-builder.less
+++ b/src/css/cfpb-chart-builder.less
@@ -279,19 +279,15 @@
   .highcharts-range-selector-label {
     display: table;
     margin-top: 0 !important;
-    transform: translateY( 415px );
     width: 100%;
     color: @gray;
 
-    .h6();
+    .chart-label();
+    transform: translateY( -5px );
 
-    .respond-to-min( 800px, {
-      transform: translateY( -5px );
-
-      .chart-label();
-
-      letter-spacing: 0;
-      text-transform: none;
+    .respond-to-max( 800px, {
+        .h6();
+        transform: translateY( 415px );
     } );
 
     .hide-on-ie9();


### PR DESCRIPTION
## Changes

- Adjusts styles so the labels aren't erroneously high bolding weight.

## Testing

- `gulp build && gulp watch` and resize the demo down to a small size. See that "Select time range" is demi bolded only.

## Screenshots
<img width="366" alt="screen shot 2018-09-07 at 1 06 39 pm" src="https://user-images.githubusercontent.com/704760/45232855-f6344e00-b29e-11e8-9511-147da34c3b89.png">
