### PR TITLE
Remove formatDate

### DIFF
--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -7,26 +7,6 @@ let UNDEFINED;
  * Returns an object with the UTC timestamp number in milliseconds
  * and human-friendly month and year for a given date in either format.
  *
- * @param {number} index -
- *   Counter starting at 0 representing the month and year for a data point.
- *   0 is January 2000, 1 is February 2000, etc.
- * @returns {number}
- *   UTC timestamp in milliseconds representing the month and year
- *   for the given date index.
- */
-function formatDate( index ) {
-  const year = Math.floor( index / 12 ) + 2000;
-  const month = index % 12;
-
-  const theDate = Date.UTC( year, month );
-
-  return theDate;
-}
-
-/**
- * Returns an object with the UTC timestamp number in milliseconds
- * and human-friendly month and year for a given date in either format.
- *
  * @param {number|string} date -
  *   UTC timestamp in milliseconds representing the month
  *   and year for a given data point, e.g. 1477958400000,
@@ -294,7 +274,6 @@ function processMapData( data ) {
 }
 
 module.exports = {
-  formatDate: formatDate,
   delinquencies: processDelinquencies,
   originations: processNumOriginationsData,
   yoy: processYoyData,

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -2,7 +2,6 @@ const processJSON = require( '../../../src/js/utils/process-json' );
 
 describe( 'process-json', () => {
 
-  const formatDate = processJSON.formatDate;
   const originations = processJSON.originations;
   const delinquencies = processJSON.delinquencies;
   const yoy = processJSON.yoy;
@@ -13,20 +12,6 @@ describe( 'process-json', () => {
 
   let data;
   let testData;
-
-  describe( 'formatDate', () => {
-
-    it( 'should convert a month index into the correct UTC timestamp ' +
-        'in milliseconds representing January 1 2000', () => {
-      expect( formatDate( 0 ) ).toBe( 946684800000 );
-    } );
-
-    it( 'should convert a month index into the correct UTC timestamp ' +
-        'in milliseconds representing November 1st 2016', () => {
-      expect( formatDate( 202 ) ).toBe( 1477958400000 );
-    } );
-
-  } );
 
   describe( 'convertDate', () => {
 


### PR DESCRIPTION
`formatDate` method does not appear to be used. This PR removes it.

## Removals

- Remove `formatDate`.

## Testing

- `gulp test` should pass.
- `gulp build && gulp watch` should run the demo without error.
