### PR TITLE
Remove unused methods and minor linter fixes

### DIFF
--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -11,23 +11,6 @@ Highcharts.setOptions( {
 } );
 
 /**
- * _getYAxisUnits - Get the text of the y-axis title
- *
- * @param {Array} array - An array of values to check.
- * @returns {string} Appropriate y-axis title.
- */
-function _getYAxisUnits( array ) {
-  const value = getFirstNumber( array );
-  if ( !value ) {
-    return value;
-  }
-  if ( value % 1000000000 < value ) {
-    return 'billions';
-  }
-  return 'millions';
-}
-
-/**
  * _getYAxisLabel - Get the text of the y-axis title.
  *
  * @param {Array} chartData - An array of values to check.

--- a/src/js/charts/LineChartComparison.js
+++ b/src/js/charts/LineChartComparison.js
@@ -1,4 +1,3 @@
-const getFirstNumber = require( '../utils/calculation' ).getFirstNumber;
 const Highcharts = require( 'highcharts/js/highstock' );
 const process = require( '../utils/process-json' );
 require( 'highcharts/js/modules/accessibility' )( Highcharts );
@@ -9,37 +8,6 @@ Highcharts.setOptions( {
     thousandsSep: ','
   }
 } );
-
-/**
- * _getYAxisUnits - Get the text of the y-axis title
- *
- * @param {Array} array - An array of values to check
- * @returns {string} Appropriate y-axis title
- */
-function _getYAxisUnits( array ) {
-  const value = getFirstNumber( array );
-  if ( !value ) {
-    return value;
-  }
-  return 'percent';
-}
-
-/**
- * _getYAxisLabel - Get the text of the y-axis title
- *
- * @param  {array} array  An array of values to check
- * @returns {string}    Appropriate y-axis title
- */
-function _getYAxisLabel( array ) {
-  const value = getFirstNumber( array );
-  if ( !value ) {
-    return value;
-  }
-  if ( value % 1000000000 < value ) {
-    return 'Volume';
-  }
-  return 'Number';
-}
 
 /**
  * _getTickValue - Convert the data point's unit to M or B.

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -1,4 +1,3 @@
-const getFirstNumber = require( '../utils/calculation' ).getFirstNumber;
 const Highcharts = require( 'highcharts/js/highstock' );
 const process = require( '../utils/process-json' );
 require( 'highcharts/js/modules/accessibility' )( Highcharts );
@@ -11,7 +10,7 @@ Highcharts.setOptions( {
 } );
 
 class LineChartIndex {
-  constructor( { el, description, data, metadata, source, yAxisLabel } ) {
+  constructor( { el, description, data, metadata, source } ) {
     data = process.originations( data[0], metadata, source );
     const options = {
       chart: {

--- a/src/js/charts/TileMap.js
+++ b/src/js/charts/TileMap.js
@@ -4,11 +4,15 @@ const process = require( '../utils/process-json' );
 require( 'highcharts/js/modules/accessibility' )( Highcharts );
 
 /**
- * Draw a legend on a chart
+ * Draw a legend on a chart.
  * @param {Object} chart A highchart chart.
  */
 function _drawLegend( chart ) {
 
+  /**
+   * @param {string} color hex color code.
+   * @returns {Object} Return a hash of box fill and stroke styles.
+   */
   function _boxStyle( color ) {
     return {
       'stroke-width': 1,
@@ -18,16 +22,33 @@ function _drawLegend( chart ) {
   }
 
   // args: (str, x, y, shape, anchorX, anchorY, useHTML, baseline, className)
-  chart.renderer.label( 'Year-over-year change (rounded to the nearest whole number)', 5, 5, null, null, null, true, false, 'label__tile-map' ).add();
-
+  const labelTx = 'Year-over-year change (rounded to the nearest whole number)';
+  chart.renderer
+    .label( labelTx, 5, 5, null, null, null, true, false, 'label__tile-map' )
+    .add();
 
   const legend = chart.renderer.g( 'legend__tile-map ' ).add();
 
-  chart.renderer.rect( 10, 48, 15, 15 ).attr( _boxStyle( getTileMapColor.green50 ) ).add( legend );
-  chart.renderer.rect( 10, 71, 15, 15 ).attr( _boxStyle( getTileMapColor.green20 ) ).add( legend );
-  chart.renderer.rect( 10, 94, 15, 15 ).attr( _boxStyle( getTileMapColor.gray5 ) ).add( legend );
-  chart.renderer.rect( 10, 117, 15, 15 ).attr( _boxStyle( getTileMapColor.pacific20 ) ).add( legend );
-  chart.renderer.rect( 10, 140, 15, 15 ).attr( _boxStyle( getTileMapColor.pacific50 ) ).add( legend );
+  chart.renderer
+    .rect( 10, 48, 15, 15 )
+    .attr( _boxStyle( getTileMapColor.green50 ) )
+    .add( legend );
+  chart.renderer
+    .rect( 10, 71, 15, 15 )
+    .attr( _boxStyle( getTileMapColor.green20 ) )
+    .add( legend );
+  chart.renderer
+    .rect( 10, 94, 15, 15 )
+    .attr( _boxStyle( getTileMapColor.gray5 ) )
+    .add( legend );
+  chart.renderer
+    .rect( 10, 117, 15, 15 )
+    .attr( _boxStyle( getTileMapColor.pacific20 ) )
+    .add( legend );
+  chart.renderer
+    .rect( 10, 140, 15, 15 )
+    .attr( _boxStyle( getTileMapColor.pacific50 ) )
+    .add( legend );
 
   chart.renderer.text( '16% or greater', 32, 61 ).add( legend );
   chart.renderer.text( '6% to 15%', 32, 84 ).add( legend );

--- a/src/js/utils/session-storage.js
+++ b/src/js/utils/session-storage.js
@@ -44,7 +44,10 @@ function setItem( key, value, storage ) {
  */
 function getItem( key, storage ) {
   storage = _getStorageType( storage );
-  return storage.getItem ? JSON.parse( storage.getItem( key ) ) : JSON.parse( storage[key] );
+  if ( storage.getItem ) {
+    return JSON.parse( storage.getItem( key ) );
+  }
+  return JSON.parse( storage[key] );
 }
 
 /**

--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -86,9 +86,9 @@ function startSauce( err, process ) {
       name: testName
     }
   };
-  request.post( opts, function( err, httpResponse, body ) {
-    if ( err ) {
-      console.error( 'An error occurred:', err );
+  request.post( opts, function( reqErr, httpResponse, body ) {
+    if ( reqErr ) {
+      console.error( 'An error occurred:', reqErr );
     }
     console.log( 'Tests started.' );
     sauceTests = body['js tests'];

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -171,6 +171,7 @@ describe( 'process-json', () => {
       expect( testData.projectedDate.timestamp ).toBe( 1246406400000 );
       // July 2009
       expect( testData[testData.length - 6][1] ).toBe( 92 );
+
       /* June 2009, the label uses the last month of data that isn't projected.
          For projected data starting with July, the label should say June. */
       expect( testData.projectedDate.label ).toBe( 'June 2009' );


### PR DESCRIPTION
## Removals

- Removes unused `_getYAxisUnits` and `_getYAxisLabel` methods from LineChartComparison chart, and `_getYAxisUnits` from LineChart chart.

## Changes

- Adds missing JSDocs, fixes some max line length warnings, fixes shadowed variable `err` warning, minor code comment updates.

## Testing

- `gulp test && gulp build && gulp watch` should launch demo without errors.
