### PR TITLE
Use Highcharts fork with temporary .flat prop fix for missing plotline label

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cfpb-chart-builder",
-  "version": "3.5.0",
+  "version": "3.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -9087,9 +9087,7 @@
       }
     },
     "highcharts": {
-      "version": "5.0.11",
-      "resolved": "https://registry.npmjs.org/highcharts/-/highcharts-5.0.11.tgz",
-      "integrity": "sha1-yOfr5MtYTqmdET9/x5JbK5A5hFM="
+      "version": "git+https://github.com/cfpb/highcharts-dist.git#0c151c2eae85e2ffaef537ecea97769c082a2d50"
     },
     "hmac-drbg": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "cf-layout": "5.0.0",
     "cf-typography": "5.0.1",
     "core-js": "2.5.7",
-    "highcharts": "5.0.11",
+    "highcharts": "https://github.com/cfpb/highcharts-dist#fix-missing-plotline-label",
     "xdr": "github:contolini/xdr"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR updates cfpb-chart-builder to temporarily use a fork of Highcharts. The fork fixes a conflicting `.flat` JS property which caused missing plotline labels (the projected data label) on all the charts that have projected data. 

The bug is in Chrome 69 and Firefox 62, in older versions of Highcharts. See this issue with description of the bug: https://github.com/highcharts/highcharts/issues/8477

Here is the bug fix, from Highcharts v6.1.2: https://github.com/highcharts/highcharts/commit/83b5d3187504d7aaec8549ba929401c73fc82284

We had to backport this bug fix to an older version of Highcharts so we can launch with cfpb-chart-builder on Highcharts v5.0.11. We will upgrade to v6 post-launch ASAP but we anticipate major CSS development to get the charts working in our supported browsers and styled to match our designs, hence this PR.

Read the "Notes" below for a detailed description of how the forked Highcharts package was created.

## Additions

-

## Removals

-

## Changes

- uses CFPB fork of [highcharts-dist](https://github.com/highcharts/highcharts-dist) repo in place of highcharts npm package
- the forked branch [`fix-missing-plotline-label`](https://github.com/highcharts/highcharts-dist/compare/master...cfpb:fix-missing-plotline-label?expand=1) includes the backported bug fix 

## Testing

- `./setup.sh`
- `gulp watch`
- go to http://localhost:5000/ and verify the "Values after ___ are projected" labels are visible on Origination activity, bar charts, and inquiry index charts

## Screenshots
![screen shot 2018-09-19 at 9 29 51 pm](https://user-images.githubusercontent.com/702526/45790787-83d74c80-bc54-11e8-9d79-dd3eb3735f94.png)
![screen shot 2018-09-19 at 9 29 46 pm](https://user-images.githubusercontent.com/702526/45790788-846fe300-bc54-11e8-8317-6bbba68eaa36.png)
![screen shot 2018-09-19 at 9 29 41 pm](https://user-images.githubusercontent.com/702526/45790789-846fe300-bc54-11e8-88d2-913fe40bc06a.png)


## Notes
more detailed description TBA, for now here were the steps i took. i'll add more context on why:

1. fix in [cfarm/highcharts source](https://github.com/highcharts/highcharts/compare/master...cfarm:fix-missing-plotline-label)
1. compile the JS in the same cfarm/highcharts repo:
  - `npm install`
  - `gulp scripts --file highcharts.src.js,highmaps.src.js,highstock.src.js,modules/stock.src.js`
1. copy these files from the `highcharts/code` folder to github [cfarm/highcharts-dist](https://github.com/highcharts/highcharts-dist/compare/master...cfarm:fix-missing-plotline-label?expand=1) (overwriting existing files):
  - highcharts.src.js
  - highmaps.src.js
  - highstock.src.js
  - modules/stock.src.js
  - js/highcharts.src.js
  - js/highmaps.src.js
  - js/highstock.src.js
  - js/modules/stock.src.js
1. minify the above files in highcharts-dist:
  - use https://closure-compiler.appspot.com/home for each file (this is akin to [highcharts' own minification process](https://github.com/highcharts/highcharts/commit/0a35fb4ed2a890d14ce87da74558aa06fe2e923d))
  - save each file as .js extension (without .src)
1. fork the fix in cfpb/highcharts and cfpb/highcharts-dist instead of cfarm


## Todos

- test in all supported browsers with Sauce

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
