### PR TITLE
Replace String.prototype.includes with String.prototype.indexOf

### DIFF
--- a/src/js/utils/process-json.js
+++ b/src/js/utils/process-json.js
@@ -90,9 +90,9 @@ function processNumOriginationsData( data, group, source ) {
   data.projectedDate = {};
   let projectedMonths = 6;
   // set number of months of projected data based on whether source filename includes 'inq' or 'den' for inquiries or denials
-  if ( source && source.includes( 'inq' ) ) {
+  if ( source && source.indexOf( 'inq_' ) !== -1 ) {
     projectedMonths = 4;
-  } else if ( source && source.includes( 'den' ) ) {
+  } else if ( source && source.indexOf( 'den_' ) !== -1 ) {
     projectedMonths = 0;
   }
   data.projectedDate.timestamp = getProjectedTimestamp( data.adjusted, projectedMonths );

--- a/test/unit_tests/utils/process-json-spec.js
+++ b/test/unit_tests/utils/process-json-spec.js
@@ -148,7 +148,7 @@ describe( 'process-json', () => {
           ]
         }
       };
-      testData = originations( data, 'test', 'inquiry_test_file.csv' );
+      testData = originations( data, 'test', 'inq_test_file.csv' );
     } );
 
     it( 'should eliminate dates before 2009', () => {
@@ -167,7 +167,7 @@ describe( 'process-json', () => {
 
     it( 'should assign the correct projected dates, ' +
         '0 months for inferred denial charts', () => {
-      const testDataDen = originations( data, 'test', 'denials_test_file.csv' );
+      const testDataDen = originations( data, 'test', 'den_test_file.csv' );
       expect( testDataDen.projectedDate.timestamp ).toBeUndefined();
       expect( testDataDen.projectedDate.label ).toBeNull();
     } );


### PR DESCRIPTION
Replaces .includes method that is unsupported in IE.

## Changes

- Replace String.prototype.includes with String.prototype.indexOf.
- Updates query string to include trailing underscore for greater specificity to filename.

## Testing

- `gulp build && gulp watch`
- `gulp test` should pass.
- Open IE11 in VirtualBox (visit `http://10.0.2.2:5000`) or in Sauce Labs and visit demo page.
- Verify that inquiry and credit tightness charts show up and have correct projected values (4 and 0 months back, respectively).

## Screenshots

<img width="687" alt="screen shot 2018-09-20 at 3 55 18 pm" src="https://user-images.githubusercontent.com/704760/45843779-7d95ae80-bcee-11e8-8764-381e8efe4914.png">

<img width="684" alt="screen shot 2018-09-20 at 3 55 26 pm" src="https://user-images.githubusercontent.com/704760/45843780-7d95ae80-bcee-11e8-892e-4c09fb299d95.png">


## Notes

- Styles have issues in IE as can be seen in screenshots.
