### PR TITLE
Patch bump to latest babel and webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,34 +14,90 @@
       }
     },
     "@babel/core": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.5.tgz",
-      "integrity": "sha512-vOyH020C56tQvte++i+rX2yokZcRfbv/kKcw+/BCRw/cK6dvsr47aCzm8oC1XHwMSEWbqrZKzZRLzLnq6SFMsg==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.1.6.tgz",
+      "integrity": "sha512-Hz6PJT6e44iUNpAn8AoyAs6B3bl60g7MJQaI0rZEar6ECzh6+srYO1xlIdssio34mPaUtAb1y+XlkkSJzok3yw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "7.0.0",
-        "@babel/generator": "7.1.5",
+        "@babel/generator": "7.1.6",
         "@babel/helpers": "7.1.5",
-        "@babel/parser": "7.1.5",
+        "@babel/parser": "7.1.6",
         "@babel/template": "7.1.2",
-        "@babel/traverse": "7.1.5",
-        "@babel/types": "7.1.5",
+        "@babel/traverse": "7.1.6",
+        "@babel/types": "7.1.6",
         "convert-source-map": "1.5.1",
-        "debug": "3.2.6",
-        "json5": "0.5.1",
+        "debug": "4.1.0",
+        "json5": "2.1.0",
         "lodash": "4.17.11",
         "resolve": "1.5.0",
         "semver": "5.5.0",
         "source-map": "0.5.7"
       },
       "dependencies": {
+        "@babel/generator": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.1.6.tgz",
+          "integrity": "sha512-brwPBtVvdYdGxtenbQgfCdDPmtkmUBZPjUoK5SXJEBuHaA5BCubh9ly65fzXz7R6o5rA76Rs22ES8Z+HCc0YIQ==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "7.1.6",
+            "jsesc": "2.5.1",
+            "lodash": "4.17.11",
+            "source-map": "0.5.7",
+            "trim-right": "1.0.1"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.1.6.tgz",
+          "integrity": "sha512-dWP6LJm9nKT6ALaa+bnL247GHHMWir3vSlZ2+IHgHgktZQx0L3Uvq2uAWcuzIe+fujRsYWBW2q622C5UvGK9iQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.1.6.tgz",
+          "integrity": "sha512-CXedit6GpISz3sC2k2FsGCUpOhUqKdyL0lqNrImQojagnUMXf8hex4AxYFRuMkNGcvJX5QAFGzB5WJQmSv8SiQ==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "7.0.0",
+            "@babel/generator": "7.1.6",
+            "@babel/helper-function-name": "7.1.0",
+            "@babel/helper-split-export-declaration": "7.0.0",
+            "@babel/parser": "7.1.6",
+            "@babel/types": "7.1.6",
+            "debug": "4.1.0",
+            "globals": "11.8.0",
+            "lodash": "4.17.11"
+          }
+        },
+        "@babel/types": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.1.6.tgz",
+          "integrity": "sha512-DMiUzlY9DSjVsOylJssxLHSgj6tWM9PRFJOGW/RaOglVOK9nzTxoOMfTfRQXGUCUQ/HmlG2efwC+XqUEJ5ay4w==",
+          "dev": true,
+          "requires": {
+            "esutils": "2.0.2",
+            "lodash": "4.17.11",
+            "to-fast-properties": "2.0.0"
+          }
+        },
         "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.0.tgz",
+          "integrity": "sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==",
           "dev": true,
           "requires": {
             "ms": "2.1.1"
+          }
+        },
+        "json5": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-2.1.0.tgz",
+          "integrity": "sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==",
+          "dev": true,
+          "requires": {
+            "minimist": "1.2.0"
           }
         },
         "lodash": {
@@ -732,9 +788,9 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.5.tgz",
-      "integrity": "sha512-pQ+2o0YyCp98XG0ODOHJd9z4GsSoV5jicSedRwCrU8uiqcJahwQiOq0asSZEb/m/lwyu6X5INvH/DSiwnQKncw==",
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.1.6.tgz",
+      "integrity": "sha512-YIBfpJNQMBkb6MCkjz/A9J76SNCSuGVamOVBgoUkLzpJD/z8ghHi9I42LQ4pulVX68N/MmImz6ZTixt7Azgexw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "7.0.0",
@@ -17010,9 +17066,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.25.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.0.tgz",
-      "integrity": "sha512-ppUNnCL9kSH7e74fro88cdT1Lfzjw8Nmx5ue8ZJimGZOvlausKBNOc0EiI1DrVKmydnLRA3FzBHoEGdpVXpiHA==",
+      "version": "4.25.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.25.1.tgz",
+      "integrity": "sha512-T0GU/3NRtO4tMfNzsvpdhUr8HnzA4LTdP2zd+e5zd6CdOH5vNKHnAlO+DvzccfhPdzqRrALOFcjYxx7K5DWmvA==",
       "dev": true,
       "requires": {
         "@webassemblyjs/ast": "1.7.11",
@@ -17446,7 +17502,7 @@
         "supports-color": "5.5.0",
         "through": "2.3.8",
         "vinyl": "2.1.0",
-        "webpack": "4.25.0"
+        "webpack": "4.25.1"
       },
       "dependencies": {
         "arr-diff": {

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.1.5",
-    "@babel/preset-env": "7.1.5",
+    "@babel/core": "7.1.6",
+    "@babel/preset-env": "7.1.6",
     "autoprefixer": "9.3.1",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "23.6.0",
@@ -72,7 +72,7 @@
     "through2": "3.0.0",
     "uglifyjs-webpack-plugin": "1.3.0",
     "vinyl-named": "1.1.0",
-    "webpack": "4.25.0",
+    "webpack": "4.25.1",
     "webpack-stream": "5.1.1"
   }
 }


### PR DESCRIPTION
## Changes

- Bump to `@babel/core` `7.1.6` from `7.1.5`
- Bump to `@babel/preset-env` `7.1.6` from `7.1.5`
- Bump to `webpack` `4.25.1` from `4.25.0`

## Testing

- `npm install && gulp build && gulp watch` should launch demo.
