### PR TITLE
Additional hiding for offscreen content

### DIFF
--- a/src/css/mixins.less
+++ b/src/css/mixins.less
@@ -39,6 +39,9 @@
          dash back the other direction with a 4px adjustment to position it.
       */
       left: -9999px;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
 
       &::before {
         position: absolute;


### PR DESCRIPTION
Sets the size and `overflow:hidden` of the offscreen content following the guidance on https://webaim.org/techniques/css/invisiblecontent/#absolutepositioning

I can only see this being an issue on large multi-display setups where the line may appear floating offscreen.

## Changes

- Sets the size and `overflow:hidden` of the off-screen tooltip legend content.
 
## Testing

- `gulp clean && gulp build && gulp watch`
- The lines in the tooltip for the line charts should be unchanged in supported browsers. 

## Screenshots

<img width="686" alt="screen shot 2018-11-26 at 4 39 58 pm" src="https://user-images.githubusercontent.com/704760/49043751-f35c4180-f199-11e8-9677-f0b390432ec1.png">

