### PR TITLE
Fix incorrect ready method call in document-ready.js

### DIFF
--- a/src/js/utils/document-ready.js
+++ b/src/js/utils/document-ready.js
@@ -87,7 +87,7 @@ function ready( callback ) {
      others are safe when readyState is "interactive". */
   if ( document.readyState === 'complete' ||
        ( !document.attachEvent && document.readyState === 'interactive' ) ) {
-    setTimeout( ready, 1 );
+    setTimeout( docReady, 1 );
   } else if ( !readyEventHandlersInstalled ) {
     // Otherwise if we don't have event handlers installed, install them.
     if ( document.addEventListener ) {


### PR DESCRIPTION
## Changes

- Changes incorrect method call in document-ready script. It was pointing to `ready` instead of `docReady`.
