### PR TITLE
Update local testing instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ for more details.
 3. Install the dependencies and compile the project with: `./setup.sh`
 
   __NOTE:__ To re-install and rebuild all the site’s assets run
-  `./setup.sh` again. See the [usage](#usage) section on updating all the
+  `./setup.sh` again. See the [usage](#development-usage) section on updating all the
   project dependencies.
 
 ### Development usage
@@ -145,12 +145,10 @@ Each time you fetch from the upstream repository (this repo), run `./setup.sh`.
 This setup script will remove and re-install the project dependencies and
 rebuild the site's JavaScript and CSS assets.
 
-To watch for changes in the source code and automatically update the running site,
-open a terminal and run:
-
-```bash
-gulp watch
-```
+To run the site on a local server,
+run `gulp watch` from the project root.
+Running in this manner will also watch for changes in the source code
+and automatically update the running site.
 
 ## Testing
 
@@ -165,7 +163,7 @@ Add the credentials locally by doing:
 1. Add valid Sauce Labs credentials to `test/config.json` (see above gist).
 
 The browser tests will take several minutes to run.
-The test script simply loads `http://localhost:8089/test` in IE VMs and reports any `window` errors.
+The test script simply loads `http://localhost:8089/` in IE VMs and reports any `window` errors.
 
 ## Getting help
 


### PR DESCRIPTION
Tried running this locally for the first time. Generally things went smoothly, but here are a few tiny tweaks to the instructions.

Two things I ran into:

1. If you're running `gulp watch`, running `npm test` in another terminal window causes a lot of output in the original window with the watch task, and the page refreshes a bunch in the browser.
1. It claims that the Sauce tests are running, but they never complete, and they aren't visible on https://saucelabs.com/u/cct-sauce

Any idea what's up with that?