### PR TITLE
Remove "All" button from bar charts for temporary fix for wrong quarterly data

### DIFF
--- a/src/js/charts/BarChart.js
+++ b/src/js/charts/BarChart.js
@@ -28,7 +28,8 @@ class BarChart {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 2, // The index of the button to appear pre-selected.
+        // The index of the button to appear pre-selected.
+        selected: 2,
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',

--- a/src/js/charts/BarChart.js
+++ b/src/js/charts/BarChart.js
@@ -28,7 +28,7 @@ class BarChart {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 'all',
+        selected: 2, // The index of the button to appear pre-selected.
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',
@@ -58,10 +58,6 @@ class BarChart {
             type: 'year',
             count: 5,
             text: '5y'
-          },
-          {
-            type: 'all',
-            text: 'All'
           }
         ]
       },

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -78,7 +78,7 @@ class LineChart {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 'all',
+        selected: 2, // The index of the button to appear pre-selected.
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -78,7 +78,8 @@ class LineChart {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 2, // The index of the button to appear pre-selected.
+        // The index of the button to appear pre-selected.
+        selected: 2,
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -28,7 +28,8 @@ class LineChartIndex {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 2, // The index of the button to appear pre-selected.
+        // The index of the button to appear pre-selected.
+        selected: 2,
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -28,7 +28,7 @@ class LineChartIndex {
       credits: false,
       rangeSelector: {
         floating: true,
-        selected: 'all',
+        selected: 2, // The index of the button to appear pre-selected.
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',


### PR DESCRIPTION
Short-term fix for https://GHE/CFGOV/platform/issues/3275

There is a press release going out tomorrow about the latest CCT data, and recently the Office of Research noticed that the bar charts are now showing the monthly data as quarterly data. Highcharts seems to be doing this as a way to fit all the bars on the "All" default view of the chart, but the quarterly number calculations it is making are wrong. 

For now, the quicker fix is to remove the "All" button from the bar charts, so that at least people are not seeing wrong data in the default view. In addition, after discussing with @niqjohnson, we are setting the default for line charts in Consumer Credit Trends to the "5y" button too, so that people are consistently viewing the same timeline across all line + bar charts on the same page.

Note that even with this change, people will still be able to see wrong quarterly numbers on the bar charts if they use the slider to zoom out to all the years, but at least it won't be the default.

**NOTE:** In addition to this change, I am next going to explore forcing the chart to show monthly data and not try to calculate quarterly data in the "All" view. If I can get that working by tomorrow, then we will deploy with that change and I'll revert the changes from this PR.

## Additions

- 

## Removals

- removed "All" button from bar charts, so that the default for bar charts is now 5 years of data, since the "All" data on the live site is smooshing together data from monthly into quarterly and displaying wrong year-over-year numbers. 

## Changes

- default to 5 years of data for all CCT charts (Line, Line-index, and Bar charts) so that timeline is the same on all CCT pages.

## Testing

Build branch with `./setup.sh`
View local page with `gulp watch`

❗️ NOTE!!!! the wrong quarterly data issue that prompted this fix is not happening in the demo page that is on this repo, because there are NOT as many months of data in this repo as what is on the live site (this repo has test data through March 2017, while the live site latest data is July 2018). The longer range of dates on the live site is making Highcharts change the bars from monthly to quarterly. To confirm that this change is happening, just check that the All button is not appearing on bar charts, but is still visible on LineChart and LineChartIndex charts, and that the default view selected for all is the "5y" button. Also use the slider to expose the older data or all of the months of data in all those charts.
- http://localhost:5000/#section-barchart
- http://localhost:5000/#section-linechart
- http://localhost:5000/#section-linechartindex

## Screenshots
Fixed charts should look like this:
![screen shot 2019-02-25 at 2 33 55 pm](https://user-images.githubusercontent.com/702526/53364450-cfc9a400-390c-11e9-9c9b-44c2ea90ea36.png)
![screen shot 2019-02-25 at 2 38 59 pm](https://user-images.githubusercontent.com/702526/53364449-cfc9a400-390c-11e9-9f72-ac254f76efc9.png)
![screen shot 2019-02-25 at 2 39 16 pm](https://user-images.githubusercontent.com/702526/53364448-cfc9a400-390c-11e9-9dfb-a27f1244813a.png)





## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
