### PR TITLE
Test IE11 instead of 10 since we dont support IE10 js

### DIFF
--- a/test/browser-tests.js
+++ b/test/browser-tests.js
@@ -77,7 +77,7 @@ function startSauce() {
     method: 'POST',
     json: {
       platforms: [
-        [ 'Windows 7', 'internet explorer', '10' ],
+        [ 'Windows 7', 'internet explorer', '11' ],
         [ 'Windows 7', 'firefox', '27' ],
         [ 'Windows 7', 'chrome', '' ],
         [ 'Linux', 'android', '' ]


### PR DESCRIPTION
Fixes #165 

## Additions

-

## Removals

-

## Changes

- changes IE browser test to use IE 11 instead of 10. JavaScript 10 is no longer supported by cfgov-refresh, but it's still useful to test an IE that is supported.

## Testing

- check out locally and run `setup.sh` and `npm test`
- Travis build should pass

## Screenshots


## Notes

-

## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
