### PR TITLE
Fix fill color styles for GeoMap selected areas

### DIFF
--- a/src/css/chart-geomap.less
+++ b/src/css/chart-geomap.less
@@ -1,7 +1,7 @@
 .cfpb-chart[data-chart-type='geo-map'] {
   .highcharts-point-select {
     color: @black;
-    fill: @black;
+    stroke-width: 3px !important;
   }
 
   // Remove drop-shadow filter from tooltip text.

--- a/src/js/charts/GeoMap.js
+++ b/src/js/charts/GeoMap.js
@@ -35,6 +35,9 @@ class GeoMap {
     }
 
     this.chartOptions = {
+      chart: {
+        styledMode: true
+      },
       credits: false,
       title: {
         text: ''

--- a/test/static/demo.js
+++ b/test/static/demo.js
@@ -37,6 +37,10 @@ const interval = setInterval( () => {
 
 const updateAllTheCharts = () => {
   setTimeout( () => {
+    map.highchart.chart.get( '10740' ).select( true );
+  }, 1000 );
+
+  setTimeout( () => {
     chart.update({
       source: 'mortgage-performance/time-series/30-89/12031;mortgage-performance/time-series/30-89/national',
       metadata: 'pct90'
@@ -67,6 +71,11 @@ const updateAllTheCharts = () => {
       metadata: 'metros'
     });
   }, 20000 );
+
+  setTimeout( () => {
+    map.highchart.chart.get( '10740' ).select( true );
+  }, 25000 );
+
 };
 
 // Sauce Labs only runs the tests for ten seconds so don't test all


### PR DESCRIPTION
Fixes bug originally documented in #162 where selected states, metro areas, and counties on the geographic maps for Mortgage Performance Trends were the wrong color, obscuring the color representing delinquency rates for the selected area.

## Additions

- turns on styledMode for GeoMap chart options, so we can use our CSS with geographic maps!
- adds selected county to the sample map on the demo page in this repo, so we can see the styles for when an area of the map is selected (which should be a 3px stroke on the selected county, metro area, or state)
- adds 3px stroke style to CSS 

## Removals

- removes style that added black fill to the selected areas

## Changes

- 

## Testing

- `gulp build` && `gulp watch`


For cfgov-refresh: 
1. delete cfpb-chart-builder in `cfgov-refresh/node_modules`
1. copy this repo folder into `cfgov-refresh/node_modules`
1. `yarn run gulp build`
1. `./runserver.sh` and visit http://localhost:8000/data-research/mortgage-performance-trends/mortgages-90-or-more-days-delinquent/ and select different areas of the map using the Select dropdowns
1. when you're done, delete `cfpb-chart-builder` from `node_modules` again and re-install the published package with `yarn add cfpb-chart-builder@v5.1.2`

## Screenshots

### Demo page in this repo:
![Screen Shot 2019-03-29 at 6 30 01 PM](https://user-images.githubusercontent.com/702526/55265933-cd7ea080-5250-11e9-8858-7b3c4d286818.png)



### cfgov-refresh:

| State: | ![Screen Shot 2019-03-29 at 6 14 40 PM](https://user-images.githubusercontent.com/702526/55265789-2b5eb880-5250-11e9-842b-fee3934061b9.png) | 
|---|---|
| Metro: | ![Screen Shot 2019-03-29 at 6 14 59 PM](https://user-images.githubusercontent.com/702526/55265786-2a2d8b80-5250-11e9-902a-6390f2659dae.png) |
| Metro: |![Screen Shot 2019-03-29 at 6 14 52 PM](https://user-images.githubusercontent.com/702526/55265787-2ac62200-5250-11e9-8227-459e4170c2b8.png) |
| Counties: | ![Screen Shot 2019-03-29 at 6 27 59 PM](https://user-images.githubusercontent.com/702526/55265846-67921900-5250-11e9-82d0-88c07556264c.png) |
| Counties: |  ![Screen Shot 2019-03-29 at 6 18 53 PM](https://user-images.githubusercontent.com/702526/55265785-2994f500-5250-11e9-95f9-50c9e3674c29.png) |



## Notes

- As you can see in the Counties screenshots above, some small areas like Philadelphia County in PA, or DC, the fill color is obscured because of the thickness of the stroke. I'm looking into this, it may need to come in a separate PR.

## Todos

-

## Checklist

* [x] Changes are limited to a single goal (no scope creep)
* [x] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [x] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [x] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
