### PR TITLE
Fix zoom button positioning and size in styledMode

### DIFF
--- a/src/css/chart-geomap.less
+++ b/src/css/chart-geomap.less
@@ -9,9 +9,15 @@
     filter: unset;
   }
 
-  // Zoom in button. Position button text.
-  .highcharts-map-navigation text {
+  // Zoom in/out buttons. Position button text.
+  .highcharts-zoom-in text {
+    transform: translateY( -5px );
     font-size: 1.2em !important;
+  }
+
+  .highcharts-zoom-out text {
+    transform: translate( 3px, -12px );
+    font-size: 1.5em !important;
   }
 
   // Set colors.

--- a/src/css/chart-geomap.less
+++ b/src/css/chart-geomap.less
@@ -11,13 +11,11 @@
 
   // Zoom in/out buttons. Position button text.
   .highcharts-zoom-in text {
-    transform: translateY( -5px );
-    font-size: 1.2em !important;
+    transform: translateY( -3px );
   }
 
   .highcharts-zoom-out text {
-    transform: translate( 3px, -12px );
-    font-size: 1.5em !important;
+    transform: translate( 3px, -3px );
   }
 
   // Set colors.


### PR DESCRIPTION
Fixes wonky zoom buttons that appeared after turning on styledMode for geographic maps in #171 

## Additions

- larger font-size for more legible zoom-out button icon (minus sign)
- custom positioning of the icon elements with CSS

## Testing

- `gulp build && gulp watch`

## Screenshots

Before
![image](https://user-images.githubusercontent.com/702526/55361833-53475980-54a6-11e9-8ce1-1bbea6bf3af0.png)


After
![Screen Shot 2019-04-01 at 5 59 01 PM](https://user-images.githubusercontent.com/702526/55362398-dd43f200-54a7-11e9-95e6-c054190b373e.png)

## Notes

- I tested this in Chrome, Firefox, IE, Edge, and mobile browsers. it is not pixel-perfect across browsers but I optimized for Chrome and IE/Edge. The minus sign appears to be 1 pixel lower or so in Firefox:
![Screen Shot 2019-04-01 at 6 02 02 PM](https://user-images.githubusercontent.com/702526/55362543-488dc400-54a8-11e9-80db-0ae146c8c345.png)


## Todos

-

## Checklist

* [ ] Changes are limited to a single goal (no scope creep)
* [ ] Code can be automatically merged (no conflicts)
* [ ] Code follows the standards laid out in the [front end playbook](https://github.com/cfpb/front-end)
* [ ] Passes all existing automated tests
* [ ] New functions include new tests
* [ ] New functions are documented (with a description, list of inputs, and expected output)
* [ ] Placeholder code is flagged
* [ ] Visually tested in supported browsers and devices
* [ ] Project documentation has been updated (including the "Unreleased" section of the CHANGELOG)
