### PR TITLE
add npm link instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,22 @@ run `gulp watch` from the project root.
 Running in this manner will also watch for changes in the source code
 and automatically update the running site.
 
+#### Development with cfgov-refresh
+
+When running the site locally, you can temporarily link changes you are making to the code with the [cfgov-refresh](https://github.com/cfpb/cfgov-refresh/) project. 
+
+1. In the cfpb-chart-builder directory, run:
+   ```
+   npm link
+   ```
+1. In the cfgov-refresh directory:
+   ```
+   ./setup.sh
+   npm link cfpb-chart-builder
+   gulp build
+   ./runserver.sh
+   ```
+
 ### Publish a release
 
 1. After merging all PRs needed for release, update the version in `package.json` using [semantic versioning](https://semver.org). This command will also tag and commit the updated version:

--- a/README.md
+++ b/README.md
@@ -165,6 +165,12 @@ When running the site locally, you can temporarily link changes you are making t
    gulp build
    ./runserver.sh
    ```
+1. When you're done and want to bring back the published package:
+   ```
+   npm unlink cfpb-chart-builder
+   yarn add cfpb-chart-builder
+   gulp build
+   ```
 
 ### Publish a release
 


### PR DESCRIPTION
From #170 - adding instructions for using `npm link` to test this codebase in cfgov-refresh.
