### PR TITLE
Set maxRange value to 7 years on bar charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4909,7 +4909,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4930,12 +4931,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4950,17 +4953,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5077,7 +5083,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5089,6 +5096,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5103,6 +5111,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5110,12 +5119,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5134,6 +5145,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5214,7 +5226,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5226,6 +5239,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5311,7 +5325,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5347,6 +5362,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5366,6 +5382,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5409,12 +5426,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/js/charts/BarChart.js
+++ b/src/js/charts/BarChart.js
@@ -15,6 +15,11 @@ class BarChart {
   constructor( { el, description, data, metadata } ) {
     data = processYoyData( data[0], metadata );
 
+    // Calculate the maximum range as the last data point minus 7 years.
+    const today = new Date( data[data.length - 1][0] );
+    const past = new Date( today ).setFullYear( today.getFullYear() - 7 );
+    const maxRangeValue = today - past;
+
     const options = {
       chart: {
         className: 'cfpb-chart__small',
@@ -30,7 +35,7 @@ class BarChart {
       rangeSelector: {
         floating: true,
         // The index of the button to appear pre-selected.
-        selected: 2,
+        selected: 3,
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',
@@ -60,6 +65,11 @@ class BarChart {
             type: 'year',
             count: 5,
             text: '5y'
+          },
+          {
+            type: 'year',
+            count: 7,
+            text: '7y'
           }
         ]
       },
@@ -73,6 +83,11 @@ class BarChart {
           groupPadding: 0,
           shadow: false,
           grouping: false
+        },
+        series: {
+          dataGrouping: {
+            enabled: false
+          }
         }
       },
       scrollbar: {
@@ -87,6 +102,7 @@ class BarChart {
       xAxis: {
         startOnTick: true,
         tickLength: 5,
+        maxRange: maxRangeValue,
         type: 'datetime',
         dateTimeLabelFormats: {
           month: '%b<br/>%Y',

--- a/src/js/charts/LineChart.js
+++ b/src/js/charts/LineChart.js
@@ -79,8 +79,7 @@ class LineChart {
       credits: false,
       rangeSelector: {
         floating: true,
-        // The index of the button to appear pre-selected.
-        selected: 2,
+        selected: 'all',
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',

--- a/src/js/charts/LineChartIndex.js
+++ b/src/js/charts/LineChartIndex.js
@@ -29,8 +29,7 @@ class LineChartIndex {
       credits: false,
       rangeSelector: {
         floating: true,
-        // The index of the button to appear pre-selected.
-        selected: 2,
+        selected: 'all',
         height: 35,
         inputEnabled: false,
         verticalAlign: 'bottom',


### PR DESCRIPTION
If we have too much data in the bar charts the values get merged together. This caps the range shown in the bar charts to 7 years. 

## Changes

- Set maxRange value to 7 years on bar charts.
- Set selected on load button to all on line charts.

## Testing

- Pull branch and run `gulp build && gulp watch`
- Visit demo at http://localhost:5000 and go to the bar charts. See that there's a "7y" button and when you drag the handles on the navigator (mini chart below the bar charts) they won't allow expansion beyond a 7 year window.

## Screenshots

<img width="686" alt="Screen Shot 2019-09-23 at 10 54 54 AM" src="https://user-images.githubusercontent.com/704760/65436863-ccd65980-ddf0-11e9-8d0f-97255eb174c7.png">
