### PR TITLE
Update outdated dependencies: core-js, babel/core, babel/preset-env, autoprefixer, postcss, webpack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.29.0",
+        "webpack": "5.30.0",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17215,9 +17215,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
-      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
+      "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32223,9 +32223,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
-      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
+      "version": "5.30.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.30.0.tgz",
+      "integrity": "sha512-Zr9NIri5yzpfmaMea2lSMV1UygbW0zQsSlGLMgKUm63ACXg6alhd1u4v5UBSBjzYKXJN6BNMGVM7w165e7NxYA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@babel/core": "7.13.10",
-        "@babel/preset-env": "7.13.10",
+        "@babel/preset-env": "7.13.12",
         "autoprefixer": "10.2.5",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "26.6.3",
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.27.1",
+        "webpack": "5.27.2",
         "webpack-stream": "6.1.2"
       }
     },
@@ -61,9 +61,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
+      "integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
       "dev": true
     },
     "node_modules/@babel/core": {
@@ -432,6 +432,20 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.13.0"
+      }
+    },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
@@ -567,9 +581,9 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
-      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
@@ -1186,15 +1200,16 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
-      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
+      "integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-dynamic-import": "^7.13.8",
@@ -1205,7 +1220,7 @@
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
         "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
         "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -1253,7 +1268,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
         "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.12",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
@@ -1327,9 +1342,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -17203,9 +17218,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.1.tgz",
-      "integrity": "sha512-rxIDsPZ3Apl3JcqiemiLmWH+hAq04YeOXqvCxNZOnTp8ZgM9NEPtbu4CaMfMEf9KShnx/Ym8uLGmM6P4XnwCoA==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.2.tgz",
+      "integrity": "sha512-brNF3N/EdvMzkaZ/Xzb8sqPn5Si3iw6meqCnmNFtcnkorZsFZCBFMa2ElpIMjx6sKWYsnUpBO2dnX+7xgj+mjg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -18244,9 +18259,9 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
-      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.12.tgz",
+      "integrity": "sha512-3eJJ841uKxeV8dcN/2yGEUy+RfgQspPEgQat85umsE1rotuquQ2AbIub4S6j7c50a2d+4myc+zSlnXeIHrOnhQ==",
       "dev": true
     },
     "@babel/core": {
@@ -18583,6 +18598,17 @@
       "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
       "dev": true
     },
+    "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining/-/plugin-bugfix-v8-spread-parameters-in-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-d0u3zWKcoZf379fOeJdr1a5WPDny4aOFZ6hlfKivgK0LY7ZxNfoaHL2fWwdGtHyVvra38FC+HVYkO+byfSA8AQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12"
+      }
+    },
     "@babel/plugin-proposal-async-generator-functions": {
       "version": "7.13.8",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
@@ -18688,9 +18714,9 @@
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.8",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
-      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.12.tgz",
+      "integrity": "sha512-fcEdKOkIB7Tf4IxrgEVeFC4zeJSTr78no9wTdBuZZbqF64kzllU0ybo2zrzm7gUQfxGhBgq4E39oRs8Zx/RMYQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
@@ -19157,15 +19183,16 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
-      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.12.tgz",
+      "integrity": "sha512-JzElc6jk3Ko6zuZgBtjOd01pf9yYDEIH8BcqVuYIuOkzOwDesoa/Nz4gIo4lBG6K861KTV9TvIgmFuT6ytOaAA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
+        "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
         "@babel/plugin-proposal-dynamic-import": "^7.13.8",
@@ -19176,7 +19203,7 @@
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
         "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
         "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.12",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
         "@babel/plugin-syntax-async-generators": "^7.8.4",
@@ -19224,7 +19251,7 @@
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
         "@babel/preset-modules": "^0.1.4",
-        "@babel/types": "^7.13.0",
+        "@babel/types": "^7.13.12",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
@@ -19291,9 +19318,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.0.tgz",
-      "integrity": "sha512-hE+HE8rnG1Z6Wzo+MhaKE5lM5eMx71T4EHJgku2E3xIfaULhDcxiiRxUYgwX8qwP1BBSlag+TdGOt6JAidIZTA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
+      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -32202,9 +32229,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.27.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.1.tgz",
-      "integrity": "sha512-rxIDsPZ3Apl3JcqiemiLmWH+hAq04YeOXqvCxNZOnTp8ZgM9NEPtbu4CaMfMEf9KShnx/Ym8uLGmM6P4XnwCoA==",
+      "version": "5.27.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.2.tgz",
+      "integrity": "sha512-brNF3N/EdvMzkaZ/Xzb8sqPn5Si3iw6meqCnmNFtcnkorZsFZCBFMa2ElpIMjx6sKWYsnUpBO2dnX+7xgj+mjg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,14 +11,14 @@
         "@cfpb/cfpb-core": "0.7.7",
         "@cfpb/cfpb-layout": "0.7.7",
         "@cfpb/cfpb-typography": "0.7.9",
-        "core-js": "3.9.0",
+        "core-js": "3.9.1",
         "highcharts": "7.2.2",
         "xdr": "0.5.3"
       },
       "devDependencies": {
-        "@babel/core": "7.13.1",
-        "@babel/preset-env": "7.13.5",
-        "autoprefixer": "10.2.4",
+        "@babel/core": "7.13.10",
+        "@babel/preset-env": "7.13.10",
+        "autoprefixer": "10.2.5",
         "babel-core": "^7.0.0-bridge.0",
         "babel-jest": "26.6.3",
         "babel-loader": "8.2.2",
@@ -39,7 +39,7 @@
         "jest-cli": "26.6.3",
         "lodash.merge": "4.6.2",
         "minimist": "1.2.5",
-        "postcss": "8.2.6",
+        "postcss": "8.2.7",
         "request": "2.88.2",
         "require-dir": "1.2.0",
         "sauce-connect-launcher": "1.3.2",
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.24.2",
+        "webpack": "5.24.4",
         "webpack-stream": "6.1.2"
       }
     },
@@ -61,23 +61,23 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
+        "@babel/helpers": "^7.13.10",
+        "@babel/parser": "^7.13.10",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -86,7 +86,7 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "engines": {
@@ -98,9 +98,9 @@
       }
     },
     "node_modules/@babel/core/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -116,9 +116,9 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.13.0",
@@ -155,24 +155,24 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -265,12 +265,13 @@
       }
     },
     "node_modules/@babel/helper-hoist-variables": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.12.13.tgz",
-      "integrity": "sha512-KSC5XSj5HreRhYQtZ3cnSnQwDzgnbdUDEFsxkN0m6Q3WrCRt72xrnZ8+h+pX7YxM7hr87zIO3a/v5p/H3TrnVw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
+      "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
@@ -398,9 +399,9 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.12.13",
@@ -420,9 +421,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
+      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -432,14 +433,14 @@
       }
     },
     "node_modules/@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.5.tgz",
-      "integrity": "sha512-8cErJEDzhZgNKzYyjCKsHuyPqtWxG8gc9h4OFSUDJu0vCAOsObPU2LcECnW0kJwh/b+uUz46lObVzIXw0fzAbA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -459,13 +460,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.17.tgz",
-      "integrity": "sha512-ZNGoFZqrnuy9H2izB2jLlnNDAfVPlGl5NhFEiFe4D84ix9GQGygF+CWMGHKuE+bpyS/AOuDQCnkiRNqW2IzS1Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
+      "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -485,25 +486,25 @@
       }
     },
     "node_modules/@babel/plugin-proposal-json-strings": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.13.tgz",
-      "integrity": "sha512-v9eEi4GiORDg8x+Dmi5r8ibOe0VXoKDeNPYcTTxdGN4eOWikrJfDJCJrr1l5gKGvsNyGJbrfMftC2dTL6oz7pg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
+      "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.13.tgz",
-      "integrity": "sha512-fqmiD3Lz7jVdK6kabeSr1PZlWSUVqSitmHEe3Z00dtGTKieWnX9beafvavc32kjORa5Bai4QNHgFDwWJP+WtSQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+      "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       },
       "peerDependencies": {
@@ -511,13 +512,13 @@
       }
     },
     "node_modules/@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.0.tgz",
-      "integrity": "sha512-UkAvFA/9+lBBL015gjA68NvKiCReNxqFLm3SdNKaM3XXoDisA7tMAIX4PmIwatFoFqMxxT3WyG9sK3MO0Kting==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+      "integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -537,13 +538,15 @@
       }
     },
     "node_modules/@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.0.tgz",
-      "integrity": "sha512-B4qphdSTp0nLsWcuei07JPKeZej4+Hd22MdnulJXQa1nCcGSBlk8FiqenGERaPZ+PuYhz4Li2Wjc8yfJvHgUMw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+      "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
       "dev": true,
       "dependencies": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.13.0"
       },
       "peerDependencies": {
@@ -551,27 +554,27 @@
       }
     },
     "node_modules/@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.13.tgz",
-      "integrity": "sha512-9+MIm6msl9sHWg58NvqpNpLtuFbmpFYk37x8kgnGzAHvX35E1FyAwSUt5hIkSoWJFSAH+iwU8bJ4fcD1zKXOzg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
+      "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.0.tgz",
-      "integrity": "sha512-OVRQOZEBP2luZrvEbNSX5FfWDousthhdEoAOpej+Tpe58HFLvqRClT89RauIvBuCDFEip7GW1eT86/5lMy2RNA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
+      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -968,9 +971,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.0.tgz",
-      "integrity": "sha512-j7397PkIB4lcn25U2dClK6VLC6pr2s3q+wbE8R3vJvY6U1UTBBj0n6F+5v6+Fd/UwfDPAorMOs2TV+T4M+owpQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
+      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-transforms": "^7.13.0",
@@ -983,14 +986,14 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.13.tgz",
-      "integrity": "sha512-aHfVjhZ8QekaNF/5aNdStCGzwTbU7SI5hUybBKlMzqIMC7w7Ho8hx5a4R/DkTHfRfLwHGGxSpFt9BfxKCoXKoA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-hoist-variables": "^7.12.13",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-hoist-variables": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       },
@@ -1183,39 +1186,39 @@
       }
     },
     "node_modules/@babel/preset-env": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.5.tgz",
-      "integrity": "sha512-xUeKBIIcbwxGevyWMSWZOW98W1lp7toITvVsMxSddCEQy932yYiF4fCB+CG3E/MXzFX3KbefgvCqEQ7TDoE6UQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
+      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.5",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.12.17",
+        "@babel/plugin-proposal-dynamic-import": "^7.13.8",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-        "@babel/plugin-proposal-json-strings": "^7.12.13",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.12.13",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.0",
+        "@babel/plugin-proposal-json-strings": "^7.13.8",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-        "@babel/plugin-proposal-object-rest-spread": "^7.13.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.12.13",
         "@babel/plugin-transform-arrow-functions": "^7.13.0",
         "@babel/plugin-transform-async-to-generator": "^7.13.0",
@@ -1232,8 +1235,8 @@
         "@babel/plugin-transform-literals": "^7.12.13",
         "@babel/plugin-transform-member-expression-literals": "^7.12.13",
         "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.12.13",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
         "@babel/plugin-transform-modules-umd": "^7.13.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
         "@babel/plugin-transform-new-target": "^7.12.13",
@@ -1249,22 +1252,22 @@
         "@babel/plugin-transform-typeof-symbol": "^7.12.13",
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
-        "@babel/preset-modules": "^0.1.3",
+        "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.13.0",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@babel/preset-env/node_modules/semver": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-      "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
       "dev": true,
       "bin": {
         "semver": "bin/semver.js"
@@ -3274,14 +3277,14 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
-      "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.5.tgz",
+      "integrity": "sha512-7H4AJZXvSsn62SqZyJCP+1AWwOuoYpUfK6ot9vm0e87XD6mT8lDywc9D9OTJPMULyGcvmIxzTAMeG2Cc+YX+fA==",
       "dev": true,
       "dependencies": {
-        "browserslist": "^4.16.1",
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
+        "browserslist": "^4.16.3",
+        "caniuse-lite": "^1.0.30001196",
+        "colorette": "^1.2.2",
         "fraction.js": "^4.0.13",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
@@ -4221,9 +4224,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001185",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-      "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+      "version": "1.0.30001197",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
+      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
       "dev": true
     },
     "node_modules/capture-exit": {
@@ -4595,9 +4598,9 @@
       }
     },
     "node_modules/colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "node_modules/combined-stream": {
@@ -4823,9 +4826,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-      "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -13177,12 +13180,12 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
-      "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.7.tgz",
+      "integrity": "sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==",
       "dev": true,
       "dependencies": {
-        "colorette": "^1.2.1",
+        "colorette": "^1.2.2",
         "nanoid": "^3.1.20",
         "source-map": "^0.6.1"
       },
@@ -17200,9 +17203,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.2.tgz",
-      "integrity": "sha512-uxxKYEY4kMNjP+D2Y+8aw5Vd7ar4pMuKCNemxV26ysr1nk0YDiQTylg9U3VZIdkmI0YHa0uC8ABxL+uGxGWWJg==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
+      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -18241,23 +18244,23 @@
       }
     },
     "@babel/compat-data": {
-      "version": "7.13.6",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.6.tgz",
-      "integrity": "sha512-VhgqKOWYVm7lQXlvbJnWOzwfAQATd2nV52koT0HZ/LdDH0m4DUDwkKYsH+IwpXb+bKPyBJzawA4I6nBKqZcpQw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.13.8.tgz",
+      "integrity": "sha512-EaI33z19T4qN3xLXsGf48M2cDqa6ei9tPZlfLdb2HC+e/cFtREiRd8hdSqDbwdLB0/+gLwqJmCYASH0z2bUdog==",
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.1.tgz",
-      "integrity": "sha512-FzeKfFBG2rmFtGiiMdXZPFt/5R5DXubVi82uYhjGX4Msf+pgYQMCFIqFXZWs5vbIYbf14VeBIgdGI03CDOOM1w==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
+      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/generator": "^7.13.9",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-module-transforms": "^7.13.0",
-        "@babel/helpers": "^7.13.0",
-        "@babel/parser": "^7.13.0",
+        "@babel/helpers": "^7.13.10",
+        "@babel/parser": "^7.13.10",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
         "@babel/types": "^7.13.0",
@@ -18266,14 +18269,14 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
         "lodash": "^4.17.19",
-        "semver": "7.0.0",
+        "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
         "source-map": {
@@ -18285,9 +18288,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.0.tgz",
-      "integrity": "sha512-zBZfgvBB/ywjx0Rgc2+BwoH/3H+lDtlgD4hBOpEv5LxRnYsm/753iRuLepqnYlynpjC3AdQxtxsoeHJoEEwOAw==",
+      "version": "7.13.9",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.13.9.tgz",
+      "integrity": "sha512-mHOOmY0Axl/JCTkxTU6Lf5sWOg/v8nUa+Xkt4zMTftX0wqmb6Sh7J8gvcehBw7q0AhrhAR+FDacKjCZ2X8K+Sw==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.13.0",
@@ -18323,21 +18326,21 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.0.tgz",
-      "integrity": "sha512-SOWD0JK9+MMIhTQiUVd4ng8f3NXhPVQvTv7D3UN4wbp/6cAHnB2EmMaU1zZA2Hh1gwme+THBrVSqTFxHczTh0Q==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
+      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -18419,12 +18422,13 @@
       }
     },
     "@babel/helper-hoist-variables": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.12.13.tgz",
-      "integrity": "sha512-KSC5XSj5HreRhYQtZ3cnSnQwDzgnbdUDEFsxkN0m6Q3WrCRt72xrnZ8+h+pX7YxM7hr87zIO3a/v5p/H3TrnVw==",
+      "version": "7.13.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.13.0.tgz",
+      "integrity": "sha512-0kBzvXiIKfsCA0y6cFEIJf4OdzfpRuNk4+YTeHZpGGc666SATFKTz6sRncwFnQk7/ugJ4dSrCj6iJuvW4Qwr2g==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/traverse": "^7.13.0",
+        "@babel/types": "^7.13.0"
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -18552,9 +18556,9 @@
       }
     },
     "@babel/helpers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.0.tgz",
-      "integrity": "sha512-aan1MeFPxFacZeSz6Ld7YZo5aPuqnKlD7+HZY75xQsueczFccP9A7V05+oe0XpLwHK3oLorPe9eaAUljL7WEaQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.13.10.tgz",
+      "integrity": "sha512-4VO883+MWPDUVRF3PhiLBUFHoX/bsLTGFpFK/HqvvfBZz2D57u9XzPVNFVBTc0PW/CWR9BXTOKt8NF4DInUHcQ==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.12.13",
@@ -18574,20 +18578,20 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.4.tgz",
-      "integrity": "sha512-uvoOulWHhI+0+1f9L4BoozY7U5cIkZ9PgJqvb041d6vypgUmtVPG4vmGm4pSggjl8BELzvHyUeJSUyEMY6b+qA==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
+      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
       "dev": true
     },
     "@babel/plugin-proposal-async-generator-functions": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.5.tgz",
-      "integrity": "sha512-8cErJEDzhZgNKzYyjCKsHuyPqtWxG8gc9h4OFSUDJu0vCAOsObPU2LcECnW0kJwh/b+uUz46lObVzIXw0fzAbA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-async-generator-functions/-/plugin-proposal-async-generator-functions-7.13.8.tgz",
+      "integrity": "sha512-rPBnhj+WgoSmgq+4gQUtXx/vOcU+UYtjy1AA/aeD61Hwj410fwYyqfUcRP3lR8ucgliVJL/G7sXcNUecC75IXA==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-remap-async-to-generator": "^7.13.0",
-        "@babel/plugin-syntax-async-generators": "^7.8.0"
+        "@babel/plugin-syntax-async-generators": "^7.8.4"
       }
     },
     "@babel/plugin-proposal-class-properties": {
@@ -18601,13 +18605,13 @@
       }
     },
     "@babel/plugin-proposal-dynamic-import": {
-      "version": "7.12.17",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.12.17.tgz",
-      "integrity": "sha512-ZNGoFZqrnuy9H2izB2jLlnNDAfVPlGl5NhFEiFe4D84ix9GQGygF+CWMGHKuE+bpyS/AOuDQCnkiRNqW2IzS1Q==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-dynamic-import/-/plugin-proposal-dynamic-import-7.13.8.tgz",
+      "integrity": "sha512-ONWKj0H6+wIRCkZi9zSbZtE/r73uOhMVHh256ys0UzfM7I3d4n+spZNWjOnJv2gzopumP2Wxi186vI8N0Y2JyQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-export-namespace-from": {
@@ -18621,33 +18625,33 @@
       }
     },
     "@babel/plugin-proposal-json-strings": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.13.tgz",
-      "integrity": "sha512-v9eEi4GiORDg8x+Dmi5r8ibOe0VXoKDeNPYcTTxdGN4eOWikrJfDJCJrr1l5gKGvsNyGJbrfMftC2dTL6oz7pg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.13.8.tgz",
+      "integrity": "sha512-w4zOPKUFPX1mgvTmL/fcEqy34hrQ1CRcGxdphBc6snDnnqJ47EZDIyop6IwXzAC8G916hsIuXB2ZMBCExC5k7Q==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-json-strings": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-logical-assignment-operators": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.12.13.tgz",
-      "integrity": "sha512-fqmiD3Lz7jVdK6kabeSr1PZlWSUVqSitmHEe3Z00dtGTKieWnX9beafvavc32kjORa5Bai4QNHgFDwWJP+WtSQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-logical-assignment-operators/-/plugin-proposal-logical-assignment-operators-7.13.8.tgz",
+      "integrity": "sha512-aul6znYB4N4HGweImqKn59Su9RS8lbUIqxtXTOcAGtNIDczoEFv+l1EhmX8rUBp3G1jMjKJm8m0jXVp63ZpS4A==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4"
       }
     },
     "@babel/plugin-proposal-nullish-coalescing-operator": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.0.tgz",
-      "integrity": "sha512-UkAvFA/9+lBBL015gjA68NvKiCReNxqFLm3SdNKaM3XXoDisA7tMAIX4PmIwatFoFqMxxT3WyG9sK3MO0Kting==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.13.8.tgz",
+      "integrity": "sha512-iePlDPBn//UhxExyS9KyeYU7RM9WScAG+D3Hhno0PLJebAEpDZMocbDe64eqynhNAnwz/vZoL/q/QB2T1OH39A==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-numeric-separator": {
@@ -18661,35 +18665,37 @@
       }
     },
     "@babel/plugin-proposal-object-rest-spread": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.0.tgz",
-      "integrity": "sha512-B4qphdSTp0nLsWcuei07JPKeZej4+Hd22MdnulJXQa1nCcGSBlk8FiqenGERaPZ+PuYhz4Li2Wjc8yfJvHgUMw==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.13.8.tgz",
+      "integrity": "sha512-DhB2EuB1Ih7S3/IRX5AFVgZ16k3EzfRbq97CxAVI1KSYcW+lexV8VZb7G7L8zuPVSdQMRn0kiBpf/Yzu9ZKH0g==",
       "dev": true,
       "requires": {
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.8",
         "@babel/helper-plugin-utils": "^7.13.0",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
         "@babel/plugin-transform-parameters": "^7.13.0"
       }
     },
     "@babel/plugin-proposal-optional-catch-binding": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.12.13.tgz",
-      "integrity": "sha512-9+MIm6msl9sHWg58NvqpNpLtuFbmpFYk37x8kgnGzAHvX35E1FyAwSUt5hIkSoWJFSAH+iwU8bJ4fcD1zKXOzg==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-catch-binding/-/plugin-proposal-optional-catch-binding-7.13.8.tgz",
+      "integrity": "sha512-0wS/4DUF1CuTmGo+NiaHfHcVSeSLj5S3e6RivPTg/2k3wOv3jO35tZ6/ZWsQhQMvdgI7CwphjQa/ccarLymHVA==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.12.13",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0"
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-optional-chaining": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.0.tgz",
-      "integrity": "sha512-OVRQOZEBP2luZrvEbNSX5FfWDousthhdEoAOpej+Tpe58HFLvqRClT89RauIvBuCDFEip7GW1eT86/5lMy2RNA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-optional-chaining/-/plugin-proposal-optional-chaining-7.13.8.tgz",
+      "integrity": "sha512-hpbBwbTgd7Cz1QryvwJZRo1U0k1q8uyBmeXOSQUjdg/A2TASkhR/rz7AyqZ/kS8kbpsNA80rOYbxySBJAqmhhQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-skip-transparent-expression-wrappers": "^7.12.1",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0"
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3"
       }
     },
     "@babel/plugin-proposal-private-methods": {
@@ -18987,9 +18993,9 @@
       }
     },
     "@babel/plugin-transform-modules-commonjs": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.0.tgz",
-      "integrity": "sha512-j7397PkIB4lcn25U2dClK6VLC6pr2s3q+wbE8R3vJvY6U1UTBBj0n6F+5v6+Fd/UwfDPAorMOs2TV+T4M+owpQ==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.13.8.tgz",
+      "integrity": "sha512-9QiOx4MEGglfYZ4XOnU79OHr6vIWUakIj9b4mioN8eQIoEh+pf5p/zEB36JpDFWA12nNMiRf7bfoRvl9Rn79Bw==",
       "dev": true,
       "requires": {
         "@babel/helper-module-transforms": "^7.13.0",
@@ -18999,14 +19005,14 @@
       }
     },
     "@babel/plugin-transform-modules-systemjs": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.12.13.tgz",
-      "integrity": "sha512-aHfVjhZ8QekaNF/5aNdStCGzwTbU7SI5hUybBKlMzqIMC7w7Ho8hx5a4R/DkTHfRfLwHGGxSpFt9BfxKCoXKoA==",
+      "version": "7.13.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.13.8.tgz",
+      "integrity": "sha512-hwqctPYjhM6cWvVIlOIe27jCIBgHCsdH2xCJVAYQm7V5yTMoilbVMi9f6wKg0rpQAOn6ZG4AOyvCqFF/hUh6+A==",
       "dev": true,
       "requires": {
-        "@babel/helper-hoist-variables": "^7.12.13",
-        "@babel/helper-module-transforms": "^7.12.13",
-        "@babel/helper-plugin-utils": "^7.12.13",
+        "@babel/helper-hoist-variables": "^7.13.0",
+        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-identifier": "^7.12.11",
         "babel-plugin-dynamic-import-node": "^2.3.3"
       }
@@ -19151,39 +19157,39 @@
       }
     },
     "@babel/preset-env": {
-      "version": "7.13.5",
-      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.5.tgz",
-      "integrity": "sha512-xUeKBIIcbwxGevyWMSWZOW98W1lp7toITvVsMxSddCEQy932yYiF4fCB+CG3E/MXzFX3KbefgvCqEQ7TDoE6UQ==",
+      "version": "7.13.10",
+      "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.13.10.tgz",
+      "integrity": "sha512-nOsTScuoRghRtUsRr/c69d042ysfPHcu+KOB4A9aAO9eJYqrkat+LF8G1yp1HD18QiwixT2CisZTr/0b3YZPXQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.5",
-        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/compat-data": "^7.13.8",
+        "@babel/helper-compilation-targets": "^7.13.10",
         "@babel/helper-plugin-utils": "^7.13.0",
         "@babel/helper-validator-option": "^7.12.17",
-        "@babel/plugin-proposal-async-generator-functions": "^7.13.5",
+        "@babel/plugin-proposal-async-generator-functions": "^7.13.8",
         "@babel/plugin-proposal-class-properties": "^7.13.0",
-        "@babel/plugin-proposal-dynamic-import": "^7.12.17",
+        "@babel/plugin-proposal-dynamic-import": "^7.13.8",
         "@babel/plugin-proposal-export-namespace-from": "^7.12.13",
-        "@babel/plugin-proposal-json-strings": "^7.12.13",
-        "@babel/plugin-proposal-logical-assignment-operators": "^7.12.13",
-        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.0",
+        "@babel/plugin-proposal-json-strings": "^7.13.8",
+        "@babel/plugin-proposal-logical-assignment-operators": "^7.13.8",
+        "@babel/plugin-proposal-nullish-coalescing-operator": "^7.13.8",
         "@babel/plugin-proposal-numeric-separator": "^7.12.13",
-        "@babel/plugin-proposal-object-rest-spread": "^7.13.0",
-        "@babel/plugin-proposal-optional-catch-binding": "^7.12.13",
-        "@babel/plugin-proposal-optional-chaining": "^7.13.0",
+        "@babel/plugin-proposal-object-rest-spread": "^7.13.8",
+        "@babel/plugin-proposal-optional-catch-binding": "^7.13.8",
+        "@babel/plugin-proposal-optional-chaining": "^7.13.8",
         "@babel/plugin-proposal-private-methods": "^7.13.0",
         "@babel/plugin-proposal-unicode-property-regex": "^7.12.13",
-        "@babel/plugin-syntax-async-generators": "^7.8.0",
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
         "@babel/plugin-syntax-class-properties": "^7.12.13",
-        "@babel/plugin-syntax-dynamic-import": "^7.8.0",
+        "@babel/plugin-syntax-dynamic-import": "^7.8.3",
         "@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-        "@babel/plugin-syntax-json-strings": "^7.8.0",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
         "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
         "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-        "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-        "@babel/plugin-syntax-optional-catch-binding": "^7.8.0",
-        "@babel/plugin-syntax-optional-chaining": "^7.8.0",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
         "@babel/plugin-syntax-top-level-await": "^7.12.13",
         "@babel/plugin-transform-arrow-functions": "^7.13.0",
         "@babel/plugin-transform-async-to-generator": "^7.13.0",
@@ -19200,8 +19206,8 @@
         "@babel/plugin-transform-literals": "^7.12.13",
         "@babel/plugin-transform-member-expression-literals": "^7.12.13",
         "@babel/plugin-transform-modules-amd": "^7.13.0",
-        "@babel/plugin-transform-modules-commonjs": "^7.13.0",
-        "@babel/plugin-transform-modules-systemjs": "^7.12.13",
+        "@babel/plugin-transform-modules-commonjs": "^7.13.8",
+        "@babel/plugin-transform-modules-systemjs": "^7.13.8",
         "@babel/plugin-transform-modules-umd": "^7.13.0",
         "@babel/plugin-transform-named-capturing-groups-regex": "^7.12.13",
         "@babel/plugin-transform-new-target": "^7.12.13",
@@ -19217,19 +19223,19 @@
         "@babel/plugin-transform-typeof-symbol": "^7.12.13",
         "@babel/plugin-transform-unicode-escapes": "^7.12.13",
         "@babel/plugin-transform-unicode-regex": "^7.12.13",
-        "@babel/preset-modules": "^0.1.3",
+        "@babel/preset-modules": "^0.1.4",
         "@babel/types": "^7.13.0",
         "babel-plugin-polyfill-corejs2": "^0.1.4",
         "babel-plugin-polyfill-corejs3": "^0.1.3",
         "babel-plugin-polyfill-regenerator": "^0.1.2",
         "core-js-compat": "^3.9.0",
-        "semver": "7.0.0"
+        "semver": "^6.3.0"
       },
       "dependencies": {
         "semver": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.0.0.tgz",
-          "integrity": "sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==",
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -20922,14 +20928,14 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "10.2.4",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.4.tgz",
-      "integrity": "sha512-DCCdUQiMD+P/as8m3XkeTUkUKuuRqLGcwD0nll7wevhqoJfMRpJlkFd1+MQh1pvupjiQuip42lc/VFvfUTMSKw==",
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.2.5.tgz",
+      "integrity": "sha512-7H4AJZXvSsn62SqZyJCP+1AWwOuoYpUfK6ot9vm0e87XD6mT8lDywc9D9OTJPMULyGcvmIxzTAMeG2Cc+YX+fA==",
       "dev": true,
       "requires": {
-        "browserslist": "^4.16.1",
-        "caniuse-lite": "^1.0.30001181",
-        "colorette": "^1.2.1",
+        "browserslist": "^4.16.3",
+        "caniuse-lite": "^1.0.30001196",
+        "colorette": "^1.2.2",
         "fraction.js": "^4.0.13",
         "normalize-range": "^0.1.2",
         "postcss-value-parser": "^4.1.0"
@@ -21684,9 +21690,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001185",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001185.tgz",
-      "integrity": "sha512-Fpi4kVNtNvJ15H0F6vwmXtb3tukv3Zg3qhKkOGUq7KJ1J6b9kf4dnNgtEAFXhRsJo0gNj9W60+wBvn0JcTvdTg==",
+      "version": "1.0.30001197",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001197.tgz",
+      "integrity": "sha512-8aE+sqBqtXz4G8g35Eg/XEaFr2N7rd/VQ6eABGBmNtcB8cN6qNJhMi6oSFy4UWWZgqgL3filHT8Nha4meu3tsw==",
       "dev": true
     },
     "capture-exit": {
@@ -21991,9 +21997,9 @@
       "dev": true
     },
     "colorette": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
-      "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+      "integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==",
       "dev": true
     },
     "combined-stream": {
@@ -22196,9 +22202,9 @@
       }
     },
     "core-js": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.0.tgz",
-      "integrity": "sha512-PyFBJaLq93FlyYdsndE5VaueA9K5cNB7CGzeCj191YYLhkQM0gdZR2SKihM70oF0wdqKSKClv/tEBOpoRmdOVQ=="
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
+      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
     },
     "core-js-compat": {
       "version": "3.9.0",
@@ -28861,12 +28867,12 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.6.tgz",
-      "integrity": "sha512-xpB8qYxgPuly166AGlpRjUdEYtmOWx2iCwGmrv4vqZL9YPVviDVPZPRXxnXr6xPZOdxQ9lp3ZBFCRgWJ7LE3Sg==",
+      "version": "8.2.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.7.tgz",
+      "integrity": "sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==",
       "dev": true,
       "requires": {
-        "colorette": "^1.2.1",
+        "colorette": "^1.2.2",
         "nanoid": "^3.1.20",
         "source-map": "^0.6.1"
       }
@@ -32196,9 +32202,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.2.tgz",
-      "integrity": "sha512-uxxKYEY4kMNjP+D2Y+8aw5Vd7ar4pMuKCNemxV26ysr1nk0YDiQTylg9U3VZIdkmI0YHa0uC8ABxL+uGxGWWJg==",
+      "version": "5.24.4",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
+      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.28.0",
+        "webpack": "5.29.0",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17215,9 +17215,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
-      "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
+      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32223,9 +32223,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.28.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
-      "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.29.0.tgz",
+      "integrity": "sha512-su24GKXk+Rh3Y/0XP6lOfF9Xgura4rXwwD7LA/5XD+SdhLvQIl09zoI8z6JeuYY/E+Jm4qyCiDByrivyt34PeA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.27.2",
+        "webpack": "5.28.0",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17218,9 +17218,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.2.tgz",
-      "integrity": "sha512-brNF3N/EdvMzkaZ/Xzb8sqPn5Si3iw6meqCnmNFtcnkorZsFZCBFMa2ElpIMjx6sKWYsnUpBO2dnX+7xgj+mjg==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
+      "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32229,9 +32229,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.27.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.2.tgz",
-      "integrity": "sha512-brNF3N/EdvMzkaZ/Xzb8sqPn5Si3iw6meqCnmNFtcnkorZsFZCBFMa2ElpIMjx6sKWYsnUpBO2dnX+7xgj+mjg==",
+      "version": "5.28.0",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.28.0.tgz",
+      "integrity": "sha512-1xllYVmA4dIvRjHzwELgW4KjIU1fW4PEuEnjsylz7k7H5HgPOctIq7W1jrt3sKH9yG5d72//XWzsHhfoWvsQVg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.24.4",
+        "webpack": "5.26.2",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17203,9 +17203,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
-      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
+      "version": "5.26.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.2.tgz",
+      "integrity": "sha512-h07tAPeQceEO3Idrevqv4ECcpMH8Zp0aUUJ+IytujWTVf6TF5PI3rKVw0Z+7rNjU4qJuEx18BykFxgRvR9VgEQ==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32202,9 +32202,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.24.4",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.24.4.tgz",
-      "integrity": "sha512-RXOdxF9hFFFhg47BryCgyFrEyyu7Y/75/uiI2DoUiTMqysK+WczVSTppvkR47oZcmI/DPaXCiCiaXBP8QjkNpA==",
+      "version": "5.26.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.2.tgz",
+      "integrity": "sha512-h07tAPeQceEO3Idrevqv4ECcpMH8Zp0aUUJ+IytujWTVf6TF5PI3rKVw0Z+7rNjU4qJuEx18BykFxgRvR9VgEQ==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "jest-cli": "26.6.3",
         "lodash.merge": "4.6.2",
         "minimist": "1.2.5",
-        "postcss": "8.2.7",
+        "postcss": "8.2.8",
         "request": "2.88.2",
         "require-dir": "1.2.0",
         "sauce-connect-launcher": "1.3.2",
@@ -13180,9 +13180,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.7.tgz",
-      "integrity": "sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
+      "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
       "dev": true,
       "dependencies": {
         "colorette": "^1.2.2",
@@ -28867,9 +28867,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.7",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.7.tgz",
-      "integrity": "sha512-DsVLH3xJzut+VT+rYr0mtvOtpTjSyqDwPf5EZWXcb0uAKfitGpTY9Ec+afi2+TgdN8rWS9Cs88UDYehKo/RvOw==",
+      "version": "8.2.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
+      "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.26.3",
+        "webpack": "5.27.1",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17203,9 +17203,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
-      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.1.tgz",
+      "integrity": "sha512-rxIDsPZ3Apl3JcqiemiLmWH+hAq04YeOXqvCxNZOnTp8ZgM9NEPtbu4CaMfMEf9KShnx/Ym8uLGmM6P4XnwCoA==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32202,9 +32202,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.26.3",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
-      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
+      "version": "5.27.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.27.1.tgz",
+      "integrity": "sha512-rxIDsPZ3Apl3JcqiemiLmWH+hAq04YeOXqvCxNZOnTp8ZgM9NEPtbu4CaMfMEf9KShnx/Ym8uLGmM6P4XnwCoA==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "terser-webpack-plugin": "5.1.1",
         "through2": "4.0.2",
         "vinyl-named": "1.1.0",
-        "webpack": "5.26.2",
+        "webpack": "5.26.3",
         "webpack-stream": "6.1.2"
       }
     },
@@ -17203,9 +17203,9 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.2.tgz",
-      "integrity": "sha512-h07tAPeQceEO3Idrevqv4ECcpMH8Zp0aUUJ+IytujWTVf6TF5PI3rKVw0Z+7rNjU4qJuEx18BykFxgRvR9VgEQ==",
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
+      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
       "dev": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.0",
@@ -32202,9 +32202,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "5.26.2",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.2.tgz",
-      "integrity": "sha512-h07tAPeQceEO3Idrevqv4ECcpMH8Zp0aUUJ+IytujWTVf6TF5PI3rKVw0Z+7rNjU4qJuEx18BykFxgRvR9VgEQ==",
+      "version": "5.26.3",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.26.3.tgz",
+      "integrity": "sha512-z/F2lt2N1fZqaud1B4SzjL3OW03eULThbBXQ2OX4LSrZX4N9k1A5d0Rje3zS2g887DTWyAV0KGqEf64ois2dhg==",
       "dev": true,
       "requires": {
         "@types/eslint-scope": "^3.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,12 +11,12 @@
         "@cfpb/cfpb-core": "0.7.7",
         "@cfpb/cfpb-layout": "0.7.7",
         "@cfpb/cfpb-typography": "0.7.10",
-        "core-js": "3.9.1",
+        "core-js": "3.10.0",
         "highcharts": "7.2.2",
         "xdr": "0.5.3"
       },
       "devDependencies": {
-        "@babel/core": "7.13.13",
+        "@babel/core": "7.13.14",
         "@babel/preset-env": "7.13.12",
         "autoprefixer": "10.2.5",
         "babel-core": "^7.0.0-bridge.0",
@@ -39,7 +39,7 @@
         "jest-cli": "26.6.3",
         "lodash.merge": "4.6.2",
         "minimist": "1.2.5",
-        "postcss": "8.2.8",
+        "postcss": "8.2.9",
         "request": "2.88.2",
         "require-dir": "1.2.0",
         "sauce-connect-launcher": "1.3.2",
@@ -67,25 +67,24 @@
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
-      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+      "integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
         "@babel/helper-compilation-targets": "^7.13.13",
-        "@babel/helper-module-transforms": "^7.13.12",
+        "@babel/helper-module-transforms": "^7.13.14",
         "@babel/helpers": "^7.13.10",
         "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.13",
-        "@babel/types": "^7.13.13",
+        "@babel/types": "^7.13.14",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
@@ -293,9 +292,9 @@
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
-      "integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
       "dev": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.13.12",
@@ -304,8 +303,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
@@ -1340,9 +1339,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -4839,9 +4838,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ==",
       "hasInstallScript": true,
       "funding": {
         "type": "opencollective",
@@ -12231,9 +12230,9 @@
       "optional": true
     },
     "node_modules/nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
       "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
@@ -13193,13 +13192,13 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-      "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
       "dev": true,
       "dependencies": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.20",
+        "nanoid": "^3.1.22",
         "source-map": "^0.6.1"
       },
       "engines": {
@@ -18263,25 +18262,24 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
-      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.14.tgz",
+      "integrity": "sha512-wZso/vyF4ki0l0znlgM4inxbdrUvCb+cVz8grxDq+6C9k6qbqoIJteQOKicaKjCipU3ISV+XedCqpL2RJJVehA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
         "@babel/helper-compilation-targets": "^7.13.13",
-        "@babel/helper-module-transforms": "^7.13.12",
+        "@babel/helper-module-transforms": "^7.13.14",
         "@babel/helpers": "^7.13.10",
         "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.13",
-        "@babel/types": "^7.13.13",
+        "@babel/types": "^7.13.14",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.1.2",
-        "lodash": "^4.17.19",
         "semver": "^6.3.0",
         "source-map": "^0.5.0"
       },
@@ -18463,9 +18461,9 @@
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
-      "integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.14.tgz",
+      "integrity": "sha512-QuU/OJ0iAOSIatyVZmfqB0lbkVP0kDRiKj34xy+QNsnVZi/PA6BoSoreeqnxxa9EHFAIL0R9XOaAR/G9WlIy5g==",
       "dev": true,
       "requires": {
         "@babel/helper-module-imports": "^7.13.12",
@@ -18474,8 +18472,8 @@
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.12"
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.14"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -19314,9 +19312,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
-      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
+      "version": "7.13.14",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
+      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -22225,9 +22223,9 @@
       }
     },
     "core-js": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.9.1.tgz",
-      "integrity": "sha512-gSjRvzkxQc1zjM/5paAmL4idJBFzuJoo+jDjF1tStYFMV2ERfD02HhahhCGXUyHxQRG4yFKVSdO6g62eoRMcDg=="
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.10.0.tgz",
+      "integrity": "sha512-MQx/7TLgmmDVamSyfE+O+5BHvG1aUGj/gHhLn1wVtm2B5u1eVIPvh7vkfjwWKNCjrTJB8+He99IntSQ1qP+vYQ=="
     },
     "core-js-compat": {
       "version": "3.9.0",
@@ -28129,9 +28127,9 @@
       "optional": true
     },
     "nanoid": {
-      "version": "3.1.20",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
-      "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
+      "version": "3.1.22",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.22.tgz",
+      "integrity": "sha512-/2ZUaJX2ANuLtTvqTlgqBQNJoQO398KyJgZloL0PZkC0dpysjncRUPsFe3DUPzz/y3h+u7C46np8RMuvF3jsSQ==",
       "dev": true
     },
     "nanomatch": {
@@ -28890,13 +28888,13 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.2.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.8.tgz",
-      "integrity": "sha512-1F0Xb2T21xET7oQV9eKuctbM9S7BC0fetoHCc4H13z0PT6haiRLP4T0ZY4XWh7iLP0usgqykT6p9B2RtOf4FPw==",
+      "version": "8.2.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.2.9.tgz",
+      "integrity": "sha512-b+TmuIL4jGtCHtoLi+G/PisuIl9avxs8IZMSmlABRwNz5RLUUACrC+ws81dcomz1nRezm5YPdXiMEzBEKgYn+Q==",
       "dev": true,
       "requires": {
         "colorette": "^1.2.2",
-        "nanoid": "^3.1.20",
+        "nanoid": "^3.1.22",
         "source-map": "^0.6.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,13 +10,13 @@
       "dependencies": {
         "@cfpb/cfpb-core": "0.7.7",
         "@cfpb/cfpb-layout": "0.7.7",
-        "@cfpb/cfpb-typography": "0.7.9",
+        "@cfpb/cfpb-typography": "0.7.10",
         "core-js": "3.9.1",
         "highcharts": "7.2.2",
         "xdr": "0.5.3"
       },
       "devDependencies": {
-        "@babel/core": "7.13.10",
+        "@babel/core": "7.13.13",
         "@babel/preset-env": "7.13.12",
         "autoprefixer": "10.2.5",
         "babel-core": "^7.0.0-bridge.0",
@@ -67,20 +67,20 @@
       "dev": true
     },
     "node_modules/@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
+      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.13",
+        "@babel/helper-module-transforms": "^7.13.12",
         "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -155,12 +155,12 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
       "dev": true,
       "dependencies": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -275,38 +275,37 @@
       }
     },
     "node_modules/@babel/helper-member-expression-to-functions": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
+      "integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "lodash": "^4.17.19"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-optimise-call-expression": {
@@ -336,24 +335,24 @@
       }
     },
     "node_modules/@babel/helper-replace-supers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
@@ -421,9 +420,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1325,26 +1324,25 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.9",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
-      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
+      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
       "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -1391,9 +1389,9 @@
       }
     },
     "node_modules/@cfpb/cfpb-typography": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@cfpb/cfpb-typography/-/cfpb-typography-0.7.9.tgz",
-      "integrity": "sha512-IF6nQwYR4hEpkZHfguDlmTBmpB5LfDJHTg+N8KCG8QZuXqAva+h8kDD8Zrf3AxFuB/AgXVF6u0StAYMcaGT+ow==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@cfpb/cfpb-typography/-/cfpb-typography-0.7.10.tgz",
+      "integrity": "sha512-gmrke01nj2fco/mSmtT8h5Uz4hGk8Am8AVATv4zn1LiF0gzDPY/RziCn4bQdRRR2o/lS6M7T+UV5//ZXHhY9Nw==",
       "dependencies": {
         "@cfpb/cfpb-core": "^0.7.7",
         "@cfpb/cfpb-icons": "^0.7.9"
@@ -18265,20 +18263,20 @@
       "dev": true
     },
     "@babel/core": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.10.tgz",
-      "integrity": "sha512-bfIYcT0BdKeAZrovpMqX2Mx5NrgAckGbwT982AkdS5GNfn3KMGiprlBAtmBcFZRUmpaufS6WZFP8trvx8ptFDw==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.13.13.tgz",
+      "integrity": "sha512-1xEs9jZAyKIouOoCmpsgk/I26PoKyvzQ2ixdRpRzfbcp1fL+ozw7TUgdDgwonbTovqRaTfRh50IXuw4QrWO0GA==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@babel/generator": "^7.13.9",
-        "@babel/helper-compilation-targets": "^7.13.10",
-        "@babel/helper-module-transforms": "^7.13.0",
+        "@babel/helper-compilation-targets": "^7.13.13",
+        "@babel/helper-module-transforms": "^7.13.12",
         "@babel/helpers": "^7.13.10",
-        "@babel/parser": "^7.13.10",
+        "@babel/parser": "^7.13.13",
         "@babel/template": "^7.12.13",
-        "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/traverse": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -18341,12 +18339,12 @@
       }
     },
     "@babel/helper-compilation-targets": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.10.tgz",
-      "integrity": "sha512-/Xju7Qg1GQO4mHZ/Kcs6Au7gfafgZnwm+a7sy/ow/tV1sHeraRUHbjdat8/UvDor4Tez+siGKDk6zIKtCPKVJA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.13.tgz",
+      "integrity": "sha512-q1kcdHNZehBwD9jYPh3WyXcsFERi39X4I59I3NadciWtNDyZ6x+GboOxncFK0kXlKIv6BJm5acncehXWUjWQMQ==",
       "dev": true,
       "requires": {
-        "@babel/compat-data": "^7.13.8",
+        "@babel/compat-data": "^7.13.12",
         "@babel/helper-validator-option": "^7.12.17",
         "browserslist": "^4.14.5",
         "semver": "^6.3.0"
@@ -18447,38 +18445,37 @@
       }
     },
     "@babel/helper-member-expression-to-functions": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.0.tgz",
-      "integrity": "sha512-yvRf8Ivk62JwisqV1rFRMxiSMDGnN6KH1/mDMmIrij4jztpQNRoHqqMG3U6apYbGRPJpgPalhva9Yd06HlUxJQ==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+      "integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.13.tgz",
-      "integrity": "sha512-NGmfvRp9Rqxy0uHSSVP+SRIW1q31a7Ji10cLBcqSDUngGentY4FRiHOFZFE1CLU5eiL0oE8reH7Tg1y99TDM/g==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+      "integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-module-transforms": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.0.tgz",
-      "integrity": "sha512-Ls8/VBwH577+pw7Ku1QkUWIyRRNHpYlts7+qSqBBFCW3I8QteB9DxfcZ5YJpOwH6Ihe/wn8ch7fMGOP1OhEIvw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.13.12.tgz",
+      "integrity": "sha512-7zVQqMO3V+K4JOOj40kxiCrMf6xlQAkewBB0eu2b03OO/Q21ZutOzjpfD79A5gtE/2OWi1nv625MrDlGlkbknQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.12.13",
-        "@babel/helper-replace-supers": "^7.13.0",
-        "@babel/helper-simple-access": "^7.12.13",
+        "@babel/helper-module-imports": "^7.13.12",
+        "@babel/helper-replace-supers": "^7.13.12",
+        "@babel/helper-simple-access": "^7.13.12",
         "@babel/helper-split-export-declaration": "^7.12.13",
         "@babel/helper-validator-identifier": "^7.12.11",
         "@babel/template": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0",
-        "lodash": "^4.17.19"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-optimise-call-expression": {
@@ -18508,24 +18505,24 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.0.tgz",
-      "integrity": "sha512-Segd5me1+Pz+rmN/NFBOplMbZG3SqRJOBlY+mA0SxAv6rjj7zJqr1AVr3SfzUVTLCv7ZLU5FycOM/SBGuLPbZw==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+      "integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
       "dev": true,
       "requires": {
-        "@babel/helper-member-expression-to-functions": "^7.13.0",
+        "@babel/helper-member-expression-to-functions": "^7.13.12",
         "@babel/helper-optimise-call-expression": "^7.12.13",
         "@babel/traverse": "^7.13.0",
-        "@babel/types": "^7.13.0"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-simple-access": {
-      "version": "7.12.13",
-      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.13.tgz",
-      "integrity": "sha512-0ski5dyYIHEfwpWGx5GPWhH35j342JaflmCeQmsPWcrOQDtCN6C1zKAVRFVbK53lPW2c9TsuLLSUDf0tIGJ5hA==",
+      "version": "7.13.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+      "integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.12.13"
+        "@babel/types": "^7.13.12"
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -18593,9 +18590,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.13.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.10.tgz",
-      "integrity": "sha512-0s7Mlrw9uTWkYua7xWr99Wpk2bnGa0ANleKfksYAES8LpWH4gW1OUr42vqKNf0us5UQNfru2wPqMqRITzq/SIQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
       "dev": true
     },
     "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": {
@@ -19301,26 +19298,25 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.0.tgz",
-      "integrity": "sha512-xys5xi5JEhzC3RzEmSGrs/b3pJW/o87SypZ+G/PhaE7uqVQNv/jlmVIBXuoh5atqQ434LfXV+sf23Oxj0bchJQ==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.13.13.tgz",
+      "integrity": "sha512-CblEcwmXKR6eP43oQGG++0QMTtCjAsa3frUuzHoiIJWpaIIi8dwMyEFUJoXRLxagGqCK+jALRwIO+o3R9p/uUg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
-        "@babel/generator": "^7.13.0",
+        "@babel/generator": "^7.13.9",
         "@babel/helper-function-name": "^7.12.13",
         "@babel/helper-split-export-declaration": "^7.12.13",
-        "@babel/parser": "^7.13.0",
-        "@babel/types": "^7.13.0",
+        "@babel/parser": "^7.13.13",
+        "@babel/types": "^7.13.13",
         "debug": "^4.1.0",
-        "globals": "^11.1.0",
-        "lodash": "^4.17.19"
+        "globals": "^11.1.0"
       }
     },
     "@babel/types": {
-      "version": "7.13.12",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.12.tgz",
-      "integrity": "sha512-K4nY2xFN4QMvQwkQ+zmBDp6ANMbVNw6BbxWmYA4qNjhR9W+Lj/8ky5MEY2Me5r+B2c6/v6F53oMndG+f9s3IiA==",
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.13.tgz",
+      "integrity": "sha512-kt+EpC6qDfIaqlP+DIbIJOclYy/A1YXs9dAf/ljbi+39Bcbc073H6jKVpXEr/EoIh5anGn5xq/yRVzKl+uIc9w==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.12.11",
@@ -19367,9 +19363,9 @@
       }
     },
     "@cfpb/cfpb-typography": {
-      "version": "0.7.9",
-      "resolved": "https://registry.npmjs.org/@cfpb/cfpb-typography/-/cfpb-typography-0.7.9.tgz",
-      "integrity": "sha512-IF6nQwYR4hEpkZHfguDlmTBmpB5LfDJHTg+N8KCG8QZuXqAva+h8kDD8Zrf3AxFuB/AgXVF6u0StAYMcaGT+ow==",
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/@cfpb/cfpb-typography/-/cfpb-typography-0.7.10.tgz",
+      "integrity": "sha512-gmrke01nj2fco/mSmtT8h5Uz4hGk8Am8AVATv4zn1LiF0gzDPY/RziCn4bQdRRR2o/lS6M7T+UV5//ZXHhY9Nw==",
       "requires": {
         "@cfpb/cfpb-core": "^0.7.7",
         "@cfpb/cfpb-icons": "^0.7.9"

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.26.3",
+    "webpack": "5.27.1",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.28.0",
+    "webpack": "5.29.0",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,14 +38,14 @@
     "@cfpb/cfpb-core": "0.7.7",
     "@cfpb/cfpb-layout": "0.7.7",
     "@cfpb/cfpb-typography": "0.7.9",
-    "core-js": "3.9.0",
+    "core-js": "3.9.1",
     "highcharts": "7.2.2",
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.13.1",
-    "@babel/preset-env": "7.13.5",
-    "autoprefixer": "10.2.4",
+    "@babel/core": "7.13.10",
+    "@babel/preset-env": "7.13.10",
+    "autoprefixer": "10.2.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "26.6.3",
     "babel-loader": "8.2.2",
@@ -66,7 +66,7 @@
     "jest-cli": "26.6.3",
     "lodash.merge": "4.6.2",
     "minimist": "1.2.5",
-    "postcss": "8.2.6",
+    "postcss": "8.2.7",
     "request": "2.88.2",
     "require-dir": "1.2.0",
     "sauce-connect-launcher": "1.3.2",
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.24.2",
+    "webpack": "5.24.4",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "jest-cli": "26.6.3",
     "lodash.merge": "4.6.2",
     "minimist": "1.2.5",
-    "postcss": "8.2.7",
+    "postcss": "8.2.8",
     "request": "2.88.2",
     "require-dir": "1.2.0",
     "sauce-connect-launcher": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.24.4",
+    "webpack": "5.26.2",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.27.2",
+    "webpack": "5.28.0",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.29.0",
+    "webpack": "5.30.0",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.26.2",
+    "webpack": "5.26.3",
     "webpack-stream": "6.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -38,12 +38,12 @@
     "@cfpb/cfpb-core": "0.7.7",
     "@cfpb/cfpb-layout": "0.7.7",
     "@cfpb/cfpb-typography": "0.7.10",
-    "core-js": "3.9.1",
+    "core-js": "3.10.0",
     "highcharts": "7.2.2",
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.13.13",
+    "@babel/core": "7.13.14",
     "@babel/preset-env": "7.13.12",
     "autoprefixer": "10.2.5",
     "babel-core": "^7.0.0-bridge.0",
@@ -66,7 +66,7 @@
     "jest-cli": "26.6.3",
     "lodash.merge": "4.6.2",
     "minimist": "1.2.5",
-    "postcss": "8.2.8",
+    "postcss": "8.2.9",
     "request": "2.88.2",
     "require-dir": "1.2.0",
     "sauce-connect-launcher": "1.3.2",

--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
   "dependencies": {
     "@cfpb/cfpb-core": "0.7.7",
     "@cfpb/cfpb-layout": "0.7.7",
-    "@cfpb/cfpb-typography": "0.7.9",
+    "@cfpb/cfpb-typography": "0.7.10",
     "core-js": "3.9.1",
     "highcharts": "7.2.2",
     "xdr": "0.5.3"
   },
   "devDependencies": {
-    "@babel/core": "7.13.10",
+    "@babel/core": "7.13.13",
     "@babel/preset-env": "7.13.12",
     "autoprefixer": "10.2.5",
     "babel-core": "^7.0.0-bridge.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   },
   "devDependencies": {
     "@babel/core": "7.13.10",
-    "@babel/preset-env": "7.13.10",
+    "@babel/preset-env": "7.13.12",
     "autoprefixer": "10.2.5",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "26.6.3",
@@ -74,7 +74,7 @@
     "terser-webpack-plugin": "5.1.1",
     "through2": "4.0.2",
     "vinyl-named": "1.1.0",
-    "webpack": "5.27.1",
+    "webpack": "5.27.2",
     "webpack-stream": "6.1.2"
   }
 }


### PR DESCRIPTION
## Changes

- Update outdated dependencies: core-js, babel/core, babel/preset-env, autoprefixer, postcss, webpack

## Testing

- `./setup.sh && gulp build && gulp watch` should launch the demo charts page and charts should not be broken.
